### PR TITLE
feat(runtime): default browser workflows to camoufox-nixos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.ai/
+.worktrees/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,72 +1,63 @@
 # Camoufox Stealth Browser 🦊
 
-**C++ level** anti-bot evasion — not JavaScript band-aids.
+Camoufox is the stealth-browser skill for sites that block standard automation.
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+## What Changed
 
-## Why Camoufox > Chrome-Based Tools
+Browser workflows are now:
 
-| Approach | Patches At | Detectable? |
-|----------|-----------|-------------|
-| **Camoufox** ✅ | C++ (compiled into browser) | No — fingerprints are genuinely different |
-| undetected-chromedriver | JS runtime | Yes — timing analysis reveals patches |
-| puppeteer-stealth | JS injection | Yes — applied after page load |
-| playwright-stealth | JS injection | Yes — same limitations |
+1. `camoufox-nixos` first on NixOS hosts that have it
+2. `distrobox` + `pybox` fallback on compatible Linux setups
 
-Most "stealth" tools patch Chrome with JavaScript after the browser starts. Anti-bot systems detect this via timing analysis and consistency checks.
+`curl_cffi` remains the separate API-only lane and still uses the legacy distrobox setup in this repo.
 
-**Camoufox is different.** It's a Firefox fork with stealth patches compiled into the C++ source code. WebGL, Canvas, and AudioContext fingerprints are genuinely spoofed — not masked by JS overrides.
-
-## Key Features
-
-- 🦊 **C++ Level Stealth** — Fingerprints baked into the browser binary
-- 📦 **Container Isolation** — Runs in distrobox, keeps host clean
-- ⚡ **Dual-Tool Design** — Camoufox for browsers, curl_cffi for fast API-only scraping
-- 🔥 **Firefox-Based** — Less fingerprinted than Chrome (bots love Chrome)
-
-## Quick Start
+## Browser Quick Start
 
 ```bash
-# Setup (first time)
-distrobox-enter pybox -- python3.14 -m pip install camoufox curl_cffi
+python scripts/camoufox-fetch.py "https://example.com" --headless
 
-# Fetch a Cloudflare-protected page
-distrobox-enter pybox -- python3.14 scripts/camoufox-fetch.py \
-  "https://yelp.com/biz/example" --headless
-
-# API scraping (no browser needed)
-distrobox-enter pybox -- python3.14 scripts/curl-api.py \
-  "https://api.example.com" --impersonate chrome120
+python scripts/camoufox-session.py \
+  --profile example \
+  --status "https://example.com"
 ```
 
-## Requirements
+The browser scripts self-detect runtime. You do not need to decide between host-native and fallback manually.
 
-- `distrobox` with a `pybox` container
-- Residential proxy for Airbnb/Yelp (datacenter IPs = instant block)
+## Setup
 
-## Tools
+If `camoufox-nixos` is already installed, the browser lane is ready.
 
-| Tool | Use Case | Speed |
-|------|----------|-------|
-| **Camoufox** | Full browser automation, JS-heavy sites | ~3-5s/page |
-| **curl_cffi** | API endpoints, no JS needed | ~100ms/request |
+If it is missing, or if you also want the `curl_cffi` lane, run:
 
-## Documentation
+```bash
+bash scripts/setup.sh
+```
 
-- [SKILL.md](SKILL.md) — Full usage guide with session management
-- [references/proxy-setup.md](references/proxy-setup.md) — Proxy configuration
-- [references/fingerprint-checks.md](references/fingerprint-checks.md) — What anti-bot systems check
+That script configures the distrobox fallback when possible and tells you what is missing when it cannot.
 
-## Comparison with Other Skills
+## Runtime Matrix
 
-This skill focuses on **doing one thing well**: C++ level stealth with Camoufox.
+| Use case | Preferred lane | Fallback |
+|----------|----------------|----------|
+| Browser automation on NixOS host | `camoufox-nixos` | `distrobox` + `pybox` |
+| Browser automation on other compatible Linux hosts | `distrobox` + `pybox` | none in this repo |
+| API-only scraping | `curl_cffi` in distrobox | none in this repo |
 
-For CAPTCHA solving, task checkpointing, and proxy rotation, see the [GitHub issues](https://github.com/kesslerio/stealth-browser-clawhub-skill/issues) for planned features.
+## State
 
-## License
+Browser state depends on runtime:
 
-Apache 2.0 — See [LICENSE](LICENSE)
+- `camoufox-nixos`: `~/.cache/camoufox-nixos`
+- legacy distrobox lane: `~/.stealth-browser/profiles/<name>/`
 
----
+## Notes
 
-Made with 🦊 by [Kessler.io](https://kessler.io)
+- `--export-cookies` still works.
+- `--import-cookies` is a legacy fallback feature.
+- This repo does not try to make `camoufox-nixos` a generic cross-platform install target.
+
+## Docs
+
+- [SKILL.md](SKILL.md) — full usage guide
+- [references/proxy-setup.md](references/proxy-setup.md) — proxy guidance
+- [references/fingerprint-checks.md](references/fingerprint-checks.md) — anti-bot fingerprint categories

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,310 +1,167 @@
 ---
 name: camoufox-stealth-browser
 homepage: https://github.com/kesslerio/camoufox-stealth-browser-clawhub-skill
-description: C++ level anti-bot browser automation using Camoufox (patched Firefox) in isolated containers. Bypasses Cloudflare Turnstile, Datadome, Airbnb, Yelp. Superior to Chrome-based solutions (undetected-chromedriver, puppeteer-stealth) which only patch at JS level. Use when: 'stealth browser', 'bypass bot detection', 'scrape protected site', standard Playwright/Selenium gets blocked. NOT for normal browser automation (use browser tool directly).
+description: C++ level anti-bot browser automation using Camoufox (patched Firefox). Browser workflows prefer camoufox-nixos on NixOS hosts and fall back to distrobox plus pybox on compatible Linux setups. Use when standard Playwright or Selenium gets blocked by Cloudflare, Datadome, Airbnb, Yelp, or similar anti-bot systems. NOT for normal browser automation.
 metadata:
   openclaw:
     emoji: "🦊"
     requires:
-      bins: ["distrobox"]
+      bins: []
       env: []
 ---
 
 # Camoufox Stealth Browser 🦊
 
-**C++ level** anti-bot evasion using Camoufox — a custom Firefox fork with stealth patches compiled into the browser itself, not bolted on via JavaScript.
+Camoufox is the stealth lane for hostile sites. It patches Firefox at the browser level instead of bolting JavaScript tricks on top after launch.
 
-## Why Camoufox > Chrome-based Solutions
+## Why Camoufox
 
-| Approach | Detection Level | Tools |
-|----------|-----------------|-------|
-| **Camoufox (this skill)** | C++ compiled patches | Undetectable fingerprints baked into browser |
-| undetected-chromedriver | JS runtime patches | Can be detected by timing analysis |
-| puppeteer-stealth | JS injection | Patches applied after page load = detectable |
-| playwright-stealth | JS injection | Same limitations |
+| Approach | Patch level | Typical weakness |
+|----------|-------------|------------------|
+| **Camoufox** | Browser/runtime | Harder to fingerprint with timing and JS consistency checks |
+| undetected-chromedriver | JS/runtime glue | Timing and environment mismatches |
+| puppeteer-stealth | JS injection | Patches land after page startup |
+| playwright-stealth | JS injection | Same class of weakness |
 
-**Camoufox patches Firefox at the source code level** — WebGL, Canvas, AudioContext fingerprints are genuinely spoofed, not masked by JavaScript overrides that anti-bot systems can detect.
+## Runtime Selection
 
-## Key Advantages
+The skill now uses this order for **browser** workflows:
 
-1. **C++ Level Stealth** — Fingerprint spoofing compiled into the browser, not JS hacks
-2. **Container Isolation** — Runs in distrobox, keeping your host system clean
-3. **Dual-Tool Approach** — Camoufox for browsers, curl_cffi for API-only (no browser overhead)
-4. **Firefox-Based** — Less fingerprinted than Chrome (everyone uses Chrome for bots)
+1. `camoufox-nixos`
+2. `distrobox` with `pybox`
+3. clear setup failure if neither exists
 
-## When to Use
-
-- Standard Playwright/Selenium gets blocked
-- Site shows Cloudflare challenge or "checking your browser"
-- Need to scrape Airbnb, Yelp, or similar protected sites
-- `puppeteer-stealth` or `undetected-chromedriver` stopped working
-- You need **actual** stealth, not JS band-aids
-
-## Tool Selection
-
-| Tool | Level | Best For |
-|------|-------|----------|
-| **Camoufox** | C++ patches | All protected sites - Cloudflare, Datadome, Yelp, Airbnb |
-| **curl_cffi** | TLS spoofing | API endpoints only - no JS needed, very fast |
+`curl_cffi` is unchanged. It remains the API-only lane and still relies on the legacy distrobox setup in this repo.
 
 ## Quick Start
 
-All scripts run in `pybox` distrobox for isolation.
+### Browser workflows
 
-⚠️ **Use `python3.14` explicitly** - pybox may have multiple Python versions with different packages installed.
-
-### 1. Setup (First Time)
+The browser scripts self-detect runtime. Use them directly:
 
 ```bash
-# Install tools in pybox (use python3.14)
-distrobox-enter pybox -- python3.14 -m pip install camoufox curl_cffi
+python scripts/camoufox-fetch.py "https://example.com" --headless
 
-# Camoufox browser downloads automatically on first run (~700MB Firefox fork)
+python scripts/camoufox-session.py \
+  --profile economist \
+  --status "https://www.economist.com"
 ```
 
-### 2. Fetch a Protected Page
+### Legacy/API setup
 
-**Browser (Camoufox):**
-```bash
-distrobox-enter pybox -- python3.14 scripts/camoufox-fetch.py "https://example.com" --headless
-```
-
-**API only (curl_cffi):**
-```bash
-distrobox-enter pybox -- python3.14 scripts/curl-api.py "https://api.example.com/endpoint"
-```
-
-## Architecture
-
-```
-┌─────────────────────────────────────────────────────────┐
-│                     OpenClaw Agent                       │
-├─────────────────────────────────────────────────────────┤
-│  distrobox-enter pybox -- python3.14 scripts/xxx.py         │
-├─────────────────────────────────────────────────────────┤
-│                      pybox Container                     │
-│         ┌─────────────┐  ┌─────────────┐               │
-│         │  Camoufox   │  │  curl_cffi  │               │
-│         │  (Firefox)  │  │  (TLS spoof)│               │
-│         └─────────────┘  └─────────────┘               │
-└─────────────────────────────────────────────────────────┘
-```
-
-## Tool Details
-
-### Camoufox  
-- **What:** Custom Firefox build with C++ level stealth patches
-- **Pros:** Best fingerprint evasion, passes Turnstile automatically
-- **Cons:** ~700MB download, Firefox-based
-- **Best for:** All protected sites - Cloudflare, Datadome, Yelp, Airbnb
-
-### curl_cffi
-- **What:** Python HTTP client with browser TLS fingerprint spoofing
-- **Pros:** No browser overhead, very fast
-- **Cons:** No JS execution, API endpoints only
-- **Best for:** Known API endpoints, mobile app reverse engineering
-
-## Critical: Proxy Requirements
-
-**Datacenter IPs (AWS, DigitalOcean) = INSTANT BLOCK on Airbnb/Yelp**
-
-You MUST use residential or mobile proxies:
-
-```python
-# Example proxy config
-proxy = "http://user:pass@residential-proxy.example.com:8080"
-```
-
-See **[references/proxy-setup.md](references/proxy-setup.md)** for proxy configuration.
-
-## Behavioral Tips
-
-Sites like Airbnb/Yelp use behavioral analysis. To avoid detection:
-
-1. **Warm up:** Don't hit target URL directly. Visit homepage first, scroll, click around.
-2. **Mouse movements:** Inject random mouse movements (Camoufox handles this).
-3. **Timing:** Add random delays (2-5s between actions), not fixed intervals.
-4. **Session stickiness:** Use same proxy IP for 10-30 min sessions, don't rotate every request.
-
-## Headless Mode Warning
-
-⚠️ Old `--headless` flag is DETECTED. Options:
-
-1. **New Headless:** Use `headless="new"` (Chrome 109+)
-2. **Xvfb:** Run headed browser in virtual display
-3. **Headed:** Just run headed if you can (most reliable)
+If `camoufox-nixos` is missing, or if you need the `curl_cffi` lane, run:
 
 ```bash
-# Xvfb approach (Linux)
-Xvfb :99 -screen 0 1920x1080x24 &
-export DISPLAY=:99
-python scripts/camoufox-fetch.py "https://example.com"
+bash scripts/setup.sh
 ```
 
-## Troubleshooting
+That script configures the distrobox fallback when `pybox` is available and tells you what is missing when it is not.
 
-| Problem | Solution |
-|---------|----------|
-| "Access Denied" immediately | Use residential proxy |
-| Cloudflare challenge loops | Try Camoufox instead of Nodriver |
-| Browser crashes in pybox | Install missing deps: `sudo dnf install gtk3 libXt` |
-| TLS fingerprint blocked | Use curl_cffi with `impersonate="chrome120"` |
-| Turnstile checkbox appears | Add mouse movement, increase wait time |
-| `ModuleNotFoundError: camoufox` | Use `python3.14` not `python` or `python3` |
-| `greenlet` segfault (exit 139) | Python version mismatch - use `python3.14` explicitly |
-| `libstdc++.so.6` errors | NixOS lib path issue - use `python3.14` in pybox |
+## When To Use
 
-### Python Version Issues (NixOS/pybox)
+- Standard Playwright or Selenium gets blocked
+- The site shows Cloudflare challenge loops
+- You need persistent authenticated browsing for hostile or paywalled sites
+- You need actual stealth rather than generic browser automation
 
-The `pybox` container may have multiple Python versions with separate site-packages:
+Do **not** use this skill for ordinary browsing or generic site testing. Use your normal browser automation tool for that.
+
+## Workflow Summary
+
+### Protected-page fetch
 
 ```bash
-# Check which Python has camoufox
-distrobox-enter pybox -- python3.14 -c "import camoufox; print('OK')"
-
-# Wrong (may use different Python)
-distrobox-enter pybox -- python3.14 scripts/camoufox-session.py ...
-
-# Correct (explicit version)
-distrobox-enter pybox -- python3.14 scripts/camoufox-session.py ...
-```
-
-If you get segfaults or import errors, always use `python3.14` explicitly.
-
-## Examples
-
-### Scrape Airbnb Listing
-
-```bash
-distrobox-enter pybox -- python3.14 scripts/camoufox-fetch.py \
-  "https://www.airbnb.com/rooms/12345" \
-  --headless --wait 10 \
-  --screenshot airbnb.png
-```
-
-### Scrape Yelp Business
-
-```bash
-distrobox-enter pybox -- python3.14 scripts/camoufox-fetch.py \
-  "https://www.yelp.com/biz/some-restaurant" \
-  --headless --wait 8 \
+python scripts/camoufox-fetch.py \
+  "https://www.yelp.com/biz/example" \
+  --headless \
+  --wait 8 \
+  --screenshot yelp.png \
   --output yelp.html
 ```
 
-### API Scraping with TLS Spoofing
+### Persistent session
 
 ```bash
-distrobox-enter pybox -- python3.14 scripts/curl-api.py \
-  "https://api.yelp.com/v3/businesses/search?term=coffee&location=SF" \
-  --headers '{"Authorization": "Bearer xxx"}'
+# Interactive login
+python scripts/camoufox-session.py \
+  --profile airbnb \
+  --login "https://www.airbnb.com/account-settings"
+
+# Reuse saved session
+python scripts/camoufox-session.py \
+  --profile airbnb \
+  --headless "https://www.airbnb.com/trips"
+
+# Check session status
+python scripts/camoufox-session.py \
+  --profile airbnb \
+  --status "https://www.airbnb.com"
 ```
 
-## Session Management
+## State Model
 
-Persistent sessions allow reusing authenticated state across runs without re-logging in.
+Browser profile state now depends on the selected runtime:
 
-### Quick Start
+- **Host-native (`camoufox-nixos`)**: `~/.cache/camoufox-nixos`
+- **Legacy distrobox fallback**: `~/.stealth-browser/profiles/<name>/`
+
+Implications:
+
+- Persistent session reuse still works in both lanes.
+- `--import-cookies` is a legacy fallback feature. If you ask for it without the distrobox lane, the script fails clearly instead of pretending parity.
+- `--export-cookies` continues to work.
+
+## `curl_cffi` Lane
+
+`curl_cffi` remains the API-only path. It is useful when:
+
+- there is no browser interaction requirement
+- you already know the API endpoint
+- browser overhead would be wasted
+
+Current repo guidance for it is still the legacy distrobox path:
 
 ```bash
-# 1. Login interactively (headed browser opens)
-distrobox-enter pybox -- python3.14 scripts/camoufox-session.py \
-  --profile airbnb --login "https://www.airbnb.com/account-settings"
-
-# Complete login in browser, then press Enter to save session
-
-# 2. Reuse session in headless mode
-distrobox-enter pybox -- python3.14 scripts/camoufox-session.py \
-  --profile airbnb --headless "https://www.airbnb.com/trips"
-
-# 3. Check session status
-distrobox-enter pybox -- python3.14 scripts/camoufox-session.py \
-  --profile airbnb --status "https://www.airbnb.com"
+distrobox enter pybox -- python3.14 scripts/curl-api.py "https://api.example.com"
 ```
 
-### Flags
+## Non-NixOS And Missing Runtime
 
-| Flag | Description |
-|------|-------------|
-| `--profile NAME` | Named profile for session storage (required) |
-| `--login` | Interactive login mode - opens headed browser |
-| `--headless` | Use saved session in headless mode |
-| `--status` | Check if session appears valid |
-| `--export-cookies FILE` | Export cookies to JSON for backup |
-| `--import-cookies FILE` | Import cookies from JSON file |
+- **NixOS hosts with `camoufox-nixos`**: browser lane is host-native by default
+- **Other Linux hosts**: use the distrobox fallback
+- **macOS / Windows**: `camoufox-nixos` is not the portability story; the repo’s portable browser guidance is still the distrobox fallback where available
 
-### Storage
+This skill does **not** try to teach every machine how to recreate `camoufox-nixos`. That wrapper is host-specific.
 
-- **Location:** `~/.stealth-browser/profiles/<name>/`
-- **Permissions:** Directory `700`, files `600`
-- **Profile names:** Letters, numbers, `_`, `-` only (1-63 chars)
+## Proxy Reminder
 
-### Cookie Handling
+For Airbnb, Yelp, Datadome, and similar targets:
 
-- **Save:** All cookies from all domains stored in browser profile
-- **Restore:** Only cookies matching target URL domain are used
-- **SSO:** If redirected to Google/auth domain, re-authenticate once and profile updates
+- datacenter IPs often get blocked immediately
+- residential or mobile proxies are usually required
+- sticky sessions matter more than rotating every request
 
-### Login Wall Detection
+See [references/proxy-setup.md](references/proxy-setup.md).
 
-The script detects session expiry using multiple signals:
+## Remote / Headed Login Notes
 
-1. **HTTP status:** 401, 403
-2. **URL patterns:** `/login`, `/signin`, `/auth`
-3. **Title patterns:** "login", "sign in", etc.
-4. **Content keywords:** "captcha", "verify", "authenticate"
-5. **Form detection:** Password input fields
+Interactive login still needs a visible browser window regardless of runtime. If you are remote, use a display-capable setup such as:
 
-If detected during `--headless` mode, you'll see:
-```
-🔒 Login wall signals: url-path, password-form
-```
+- local desktop session
+- SSH with display forwarding where supported
+- VNC or similar remote desktop
 
-Re-run with `--login` to refresh the session.
+## Troubleshooting
 
-### Remote Login (SSH)
-
-Since `--login` requires a visible browser, you need display forwarding:
-
-**X11 Forwarding (Preferred):**
-```bash
-# Connect with X11 forwarding
-ssh -X user@server
-
-# Run login (opens browser on your local machine)
-distrobox-enter pybox -- python3.14 scripts/camoufox-session.py \
-  --profile mysite --login "https://example.com"
-```
-
-**VNC Alternative:**
-```bash
-# On server: start VNC session
-vncserver :1
-
-# On client: connect to VNC
-vncviewer server:1
-
-# In VNC session: run login
-distrobox-enter pybox -- python3.14 scripts/camoufox-session.py \
-  --profile mysite --login "https://example.com"
-```
-
-### Security Notes
-
-⚠️ **Cookies are credentials.** Treat profile directories like passwords:
-- Profile dirs have `chmod 700` (owner only)
-- Cookie exports have `chmod 600`
-- Don't share profiles or exported cookies over insecure channels
-- Consider encrypting backups
-
-### Limitations
-
-| Limitation | Reason |
-|------------|--------|
-| localStorage/sessionStorage not exported | Use browser profile instead (handles automatically) |
-| IndexedDB not portable | Stored in browser profile, not cookie export |
-| No parallel profile access | No file locking in v1; use one process per profile |
+| Problem | Meaning | What to do |
+|---------|---------|------------|
+| `No supported browser runtime found` | Neither `camoufox-nixos` nor valid distrobox fallback was detected | Install the host wrapper or configure distrobox plus pybox |
+| `--import-cookies requires the legacy distrobox fallback` | Host-native lane cannot honestly reproduce that legacy import flow | Use the fallback lane for that operation |
+| Browser lane works but `curl-api.py` does not | `curl_cffi` lane is still legacy-path setup in this repo | Run `bash scripts/setup.sh` |
+| Immediate block or challenge loop | Proxy quality or behavior issue | Use residential/mobile proxy and increase wait time |
 
 ## References
 
-- [references/proxy-setup.md](references/proxy-setup.md) — Proxy configuration guide
-- [references/fingerprint-checks.md](references/fingerprint-checks.md) — What anti-bot systems check
+- [README.md](README.md) — repo overview
+- [references/proxy-setup.md](references/proxy-setup.md) — proxy guidance
+- [references/fingerprint-checks.md](references/fingerprint-checks.md) — anti-bot fingerprint categories

--- a/scripts/camoufox-fetch.py
+++ b/scripts/camoufox-fetch.py
@@ -15,91 +15,188 @@ Options:
     --headless        Run headless (still stealthy with Camoufox)
 """
 
-import asyncio
+from __future__ import annotations
+
 import argparse
+import json
 import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
 
-try:
+from runtime_support import (
+    BrowserRuntimeError,
+    detect_browser_runtime,
+    payload_error_message,
+    require_ok,
+    run_camoufox_nixos,
+    run_distrobox_fallback,
+)
+
+
+def print_runtime_error(message: str) -> int:
+    print(f"Error: {message}", file=sys.stderr)
+    return 1
+
+
+def print_block_indicators(content: str) -> None:
+    if "Access Denied" in content or "blocked" in content.lower():
+        print("⚠️  Warning: Page may still be blocked. Check proxy quality.")
+    elif "challenge" in content.lower() and "cloudflare" in content.lower():
+        print("⚠️  Warning: Cloudflare challenge detected. Increase wait time.")
+    else:
+        print("✅ No obvious block indicators detected")
+
+
+def fetch_page_legacy(
+    url: str,
+    wait: int = 8,
+    screenshot: str | None = None,
+    output: str | None = None,
+    proxy: str | None = None,
+    headless: bool = False,
+) -> int:
+    import asyncio
     from camoufox.async_api import AsyncCamoufox
-except ImportError:
-    print("Error: camoufox not installed. Run:")
-    print("  pip install camoufox")
-    print("  python -c 'import camoufox; camoufox.install()'")
-    sys.exit(1)
+
+    async def _run() -> int:
+        print("🥷 Starting Camoufox browser (max stealth)...")
+
+        config = {"headless": headless}
+        if proxy:
+            if "@" in proxy:
+                auth_part = proxy.split("@")[0].replace("http://", "").replace("https://", "")
+                host_part = proxy.split("@")[1]
+                user, password = auth_part.split(":")
+                host, port = host_part.split(":")
+                config["proxy"] = {
+                    "server": f"http://{host}:{port}",
+                    "username": user,
+                    "password": password,
+                }
+            else:
+                config["proxy"] = {"server": proxy}
+
+        async with AsyncCamoufox(**config) as browser:
+            page = await browser.new_page()
+
+            print(f"📡 Navigating to: {url}")
+            await page.goto(url, wait_until="domcontentloaded")
+
+            print(f"⏳ Waiting {wait}s for anti-bot resolution...")
+            await asyncio.sleep(wait)
+
+            title = await page.title()
+            print(f"📄 Page title: {title}")
+
+            content = await page.content()
+            print_block_indicators(content)
+
+            if screenshot:
+                await page.screenshot(path=screenshot, full_page=True)
+                print(f"📸 Screenshot saved: {screenshot}")
+
+            if output:
+                with open(output, "w", encoding="utf-8") as handle:
+                    handle.write(content)
+                print(f"💾 HTML saved: {output}")
+            else:
+                print(f"\n✅ Success! Page loaded ({len(content)} bytes)")
+                print(f"   Final URL: {page.url}")
+
+        return 0
+
+    return asyncio.run(_run())
 
 
-async def fetch_page(url: str, wait: int = 8, screenshot: str = None,
-                     output: str = None, proxy: str = None, headless: bool = False):
-    """Fetch a page using Camoufox stealth browser."""
-    
-    print(f"🥷 Starting Camoufox browser (max stealth)...")
-    
-    # Camoufox config
-    config = {
-        "headless": headless,
-    }
-    
-    if proxy:
-        # Parse proxy URL
-        if "@" in proxy:
-            # Has auth: http://user:pass@host:port
-            auth_part = proxy.split("@")[0].replace("http://", "").replace("https://", "")
-            host_part = proxy.split("@")[1]
-            user, password = auth_part.split(":")
-            host, port = host_part.split(":")
-            config["proxy"] = {
-                "server": f"http://{host}:{port}",
-                "username": user,
-                "password": password,
-            }
-        else:
-            config["proxy"] = {"server": proxy}
-    
-    async with AsyncCamoufox(**config) as browser:
-        page = await browser.new_page()
-        
-        print(f"📡 Navigating to: {url}")
-        await page.goto(url, wait_until="domcontentloaded")
-        
-        # Wait for anti-bot to resolve
-        print(f"⏳ Waiting {wait}s for anti-bot resolution...")
-        await asyncio.sleep(wait)
-        
-        # Get page info
-        title = await page.title()
-        print(f"📄 Page title: {title}")
-        
-        # Get content
-        content = await page.content()
-        
-        # Check for block indicators
-        if "Access Denied" in content or "blocked" in content.lower():
-            print("⚠️  Warning: Page may still be blocked. Check proxy quality.")
-        elif "challenge" in content.lower() and "cloudflare" in content.lower():
-            print("⚠️  Warning: Cloudflare challenge detected. Increase wait time.")
-        else:
-            print("✅ No obvious block indicators detected")
-        
-        # Screenshot
-        if screenshot:
-            await page.screenshot(path=screenshot, full_page=True)
-            print(f"📸 Screenshot saved: {screenshot}")
-        
-        # Save HTML
-        if output:
-            with open(output, 'w', encoding='utf-8') as f:
-                f.write(content)
-            print(f"💾 HTML saved: {output}")
-        
-        # Summary
-        if not output:
-            print(f"\n✅ Success! Page loaded ({len(content)} bytes)")
-            print(f"   Final URL: {page.url}")
-        
-        return content
+def fetch_page_host_native(
+    url: str,
+    wait: int = 8,
+    screenshot: str | None = None,
+    output: str | None = None,
+    proxy: str | None = None,
+    headless: bool = False,
+) -> int:
+    selection = detect_browser_runtime()
+    runtime = selection.runtime
+    if runtime is None:
+        return print_runtime_error(selection.error_message or "No supported browser runtime found.")
+
+    if runtime.kind != "host-native":
+        return run_distrobox_fallback(Path(__file__).resolve(), sys.argv[1:], runtime)
+
+    print("🥷 Starting Camoufox browser (NixOS-native runtime)...")
+
+    with tempfile.TemporaryDirectory(prefix="camoufox-fetch-") as state_root:
+        env = {"CAMOUFOX_NIXOS_STATE_ROOT": state_root}
+        profile = f"fetch-{uuid.uuid4().hex[:10]}"
+        open_args = ["open", "--profile", profile]
+        if headless:
+            open_args.append("--headless")
+        if proxy:
+            open_args.extend(["--proxy", proxy])
+        open_args.append(url)
+
+        open_payload = run_camoufox_nixos(runtime, open_args, extra_env=env)
+        require_ok(open_payload, "Failed to open browser session.")
+        session_id = open_payload.get("sessionId")
+        if not isinstance(session_id, str) or not session_id:
+            raise BrowserRuntimeError("camoufox-nixos did not return a session id.")
+
+        try:
+            print(f"📡 Navigating to: {url}")
+            print(f"⏳ Waiting {wait}s for anti-bot resolution...")
+            time.sleep(wait)
+
+            eval_payload = run_camoufox_nixos(
+                runtime,
+                ["eval", "--session", session_id, "document.documentElement.outerHTML"],
+                extra_env=env,
+            )
+            require_ok(eval_payload, "Failed to read page HTML.")
+            content = eval_payload.get("data", {}).get("result", "")
+            if not isinstance(content, str):
+                content = json.dumps(content)
+
+            page = eval_payload.get("page") or open_payload.get("page") or {}
+            title = page.get("title") or ""
+            final_url = page.get("url") or url
+            print(f"📄 Page title: {title}")
+            print_block_indicators(content)
+
+            if screenshot:
+                screenshot_path = str(Path(screenshot).expanduser())
+                screenshot_payload = run_camoufox_nixos(
+                    runtime,
+                    ["screenshot", "--session", session_id, screenshot_path],
+                    extra_env=env,
+                )
+                require_ok(screenshot_payload, "Failed to capture screenshot.")
+                print(f"📸 Screenshot saved: {screenshot_path}")
+
+            if output:
+                output_path = Path(output).expanduser()
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(content, encoding="utf-8")
+                print(f"💾 HTML saved: {output_path}")
+            else:
+                print(f"\n✅ Success! Page loaded ({len(content)} bytes)")
+                print(f"   Final URL: {final_url}")
+
+            return 0
+        finally:
+            close_payload = run_camoufox_nixos(
+                runtime,
+                ["close", "--session", session_id],
+                extra_env=env,
+            )
+            if close_payload.get("ok") is not True:
+                message = payload_error_message(close_payload, "Failed to close browser session.")
+                print(f"Warning: {message}", file=sys.stderr)
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser(description="Camoufox stealth browser fetch (max evasion)")
     parser.add_argument("url", help="URL to fetch")
     parser.add_argument("--wait", type=int, default=8, help="Wait time in seconds (default: 8)")
@@ -107,20 +204,34 @@ def main():
     parser.add_argument("--output", help="Save HTML to file")
     parser.add_argument("--proxy", help="Proxy URL (http://user:pass@host:port)")
     parser.add_argument("--headless", action="store_true", help="Run headless")
-    
+    parser.add_argument("--runtime", choices=("auto", "legacy"), default="auto", help=argparse.SUPPRESS)
+
     args = parser.parse_args()
-    
-    asyncio.run(
-        fetch_page(
+
+    try:
+        if args.runtime == "legacy":
+            return fetch_page_legacy(
+                url=args.url,
+                wait=args.wait,
+                screenshot=args.screenshot,
+                output=args.output,
+                proxy=args.proxy,
+                headless=args.headless,
+            )
+
+        return fetch_page_host_native(
             url=args.url,
             wait=args.wait,
             screenshot=args.screenshot,
             output=args.output,
             proxy=args.proxy,
-            headless=args.headless
+            headless=args.headless,
         )
-    )
+    except ImportError:
+        return print_runtime_error("camoufox not installed in the selected legacy runtime.")
+    except BrowserRuntimeError as exc:
+        return print_runtime_error(str(exc))
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/camoufox-session.py
+++ b/scripts/camoufox-session.py
@@ -7,23 +7,30 @@ Usage:
       [--import-cookies FILE] [--export-cookies FILE] URL
 """
 
+from __future__ import annotations
+
 import argparse
 import asyncio
 import json
 import os
 import re
 import sys
+import tempfile
+import time
 from pathlib import Path
 from typing import Iterable, List, Optional, Tuple
 from urllib.parse import urlparse
 
-try:
-    from camoufox.async_api import AsyncCamoufox
-except ImportError:
-    print("Error: camoufox not installed. Run:")
-    print("  pip install camoufox")
-    print("  python -c 'import camoufox; camoufox.install()'")
-    sys.exit(1)
+from runtime_support import (
+    BrowserRuntime,
+    BrowserRuntimeError,
+    detect_browser_runtime,
+    find_distrobox_runtime,
+    payload_error_message,
+    require_ok,
+    run_camoufox_nixos,
+    run_distrobox_fallback,
+)
 
 
 PROFILE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$")
@@ -67,28 +74,14 @@ def chmod_file(path: Path) -> None:
 
 
 def domain_matches(cookie_domain: str, host: str) -> bool:
-    """Check if cookie domain matches host.
-    
-    Per RFC 6265, the leading dot is ignored for matching purposes.
-    We match if host equals the domain or is a subdomain of it.
-    This is intentionally permissive to handle various cookie export formats.
-    """
     if not cookie_domain or not host:
         return False
-    
-    # Normalize to lowercase for case-insensitive comparison
+
     cookie_domain = cookie_domain.lower().lstrip(".")
     host = host.lower()
-    
-    # Exact match
     if host == cookie_domain:
         return True
-    
-    # Subdomain match (host ends with .domain)
-    if host.endswith("." + cookie_domain):
-        return True
-    
-    return False
+    return host.endswith("." + cookie_domain)
 
 
 def filter_cookies_for_host(cookies: Iterable[dict], host: str) -> List[dict]:
@@ -166,6 +159,154 @@ async def wait_for_enter(prompt: str) -> None:
     await asyncio.get_running_loop().run_in_executor(None, lambda: input(prompt))
 
 
+def print_runtime_error(message: str) -> int:
+    print(f"Error: {message}", file=sys.stderr)
+    return 1
+
+
+def filter_storage_state_for_host(path: Path, host: str) -> List[dict]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    cookies = payload.get("cookies", [])
+    if not isinstance(cookies, list):
+        return []
+    return filter_cookies_for_host(cookies, host)
+
+
+def detect_login_wall_host_native(page: dict, content: str, has_password_field: bool) -> Tuple[bool, List[str]]:
+    signals = login_wall_signals(page.get("url", ""), page.get("title", ""), content)
+    if has_password_field:
+        signals.append("password-form")
+    return bool(signals), signals
+
+
+def load_page_state_host_native(
+    runtime: BrowserRuntime,
+    session_id: str,
+) -> Tuple[dict, str, bool]:
+    html_payload = run_camoufox_nixos(
+        runtime,
+        ["eval", "--session", session_id, "document.documentElement.outerHTML"],
+    )
+    require_ok(html_payload, "Failed to read page HTML.")
+    content = html_payload.get("data", {}).get("result", "")
+    if not isinstance(content, str):
+        content = json.dumps(content)
+
+    password_payload = run_camoufox_nixos(
+        runtime,
+        [
+            "eval",
+            "--session",
+            session_id,
+            "Boolean(document.querySelector(\"input[type='password'], input[name='password'], input[autocomplete='current-password']\"))",
+        ],
+    )
+    require_ok(password_payload, "Failed to inspect page login state.")
+    has_password_field = bool(password_payload.get("data", {}).get("result"))
+    return html_payload.get("page") or {}, content, has_password_field
+
+
+def export_cookies_host_native(
+    runtime: BrowserRuntime,
+    session_id: str,
+    host: str,
+    export_path: Path,
+) -> None:
+    with tempfile.NamedTemporaryFile(prefix="camoufox-storage-", suffix=".json", delete=False) as handle:
+        storage_path = Path(handle.name)
+    try:
+        storage_payload = run_camoufox_nixos(
+            runtime,
+            ["storage-state", "--session", session_id, str(storage_path)],
+        )
+        require_ok(storage_payload, "Failed to export storage state.")
+        matched = filter_storage_state_for_host(storage_path, host)
+        save_cookies(export_path, matched)
+        print(f"🍪 Exported {len(matched)} cookies to: {export_path}")
+    finally:
+        storage_path.unlink(missing_ok=True)
+
+
+def run_session_host_native(
+    runtime: BrowserRuntime,
+    url: str,
+    profile_name: str,
+    login_mode: bool,
+    headless: bool,
+    export_cookies: Optional[Path],
+    import_cookies: Optional[Path],
+    status_only: bool,
+) -> int:
+    if import_cookies:
+        fallback = find_distrobox_runtime()
+        if fallback is not None:
+            return run_distrobox_fallback(Path(__file__).resolve(), sys.argv[1:], fallback)
+        print("Error: --import-cookies requires the legacy distrobox fallback.", file=sys.stderr)
+        return 2
+
+    host = extract_host(url)
+    if not host:
+        print("Error: Invalid URL (missing host)")
+        return 2
+
+    print("🥷 Starting Camoufox persistent session (NixOS-native runtime)...")
+
+    open_args = ["open", "--profile", profile_name]
+    if headless or status_only or not login_mode:
+        open_args.append("--headless")
+    open_args.append(url)
+
+    open_payload = run_camoufox_nixos(runtime, open_args)
+    require_ok(open_payload, "Failed to open session.")
+    session_id = open_payload.get("sessionId")
+    if not isinstance(session_id, str) or not session_id:
+        raise BrowserRuntimeError("camoufox-nixos did not return a session id.")
+
+    try:
+        print(f"📡 Navigating to: {url}")
+        time.sleep(2)
+
+        page, content, has_password_field = load_page_state_host_native(runtime, session_id)
+        login_wall, signals = detect_login_wall_host_native(page, content, has_password_field)
+        if login_wall:
+            print(f"🔒 Login wall signals: {', '.join(signals)}")
+        else:
+            print("✅ No obvious login wall detected")
+
+        if status_only:
+            with tempfile.NamedTemporaryFile(prefix="camoufox-status-", suffix=".json", delete=False) as handle:
+                storage_path = Path(handle.name)
+            try:
+                storage_payload = run_camoufox_nixos(
+                    runtime,
+                    ["storage-state", "--session", session_id, str(storage_path)],
+                )
+                require_ok(storage_payload, "Failed to inspect stored cookies.")
+                matched = filter_storage_state_for_host(storage_path, host)
+            finally:
+                storage_path.unlink(missing_ok=True)
+            print(f"📦 Profile: {profile_name}")
+            print(f"   Stored cookies for {host}: {len(matched)}")
+            return 0
+
+        if login_mode:
+            print("🧭 Login mode enabled (headed).")
+            if login_wall:
+                print("   Complete login in the open browser window.")
+            asyncio.run(wait_for_enter("Press Enter to save session and exit... "))
+
+        if export_cookies:
+            export_cookies_host_native(runtime, session_id, host, export_cookies)
+
+        return 0
+    finally:
+        close_payload = run_camoufox_nixos(runtime, ["close", "--session", session_id])
+        if close_payload.get("ok") is not True:
+            message = payload_error_message(close_payload, "Failed to close session.")
+            print(f"Warning: {message}", file=sys.stderr)
+
+
 async def run_session(
     url: str,
     profile_name: str,
@@ -175,6 +316,8 @@ async def run_session(
     import_cookies: Optional[Path],
     status_only: bool,
 ) -> int:
+    from camoufox.async_api import AsyncCamoufox
+
     profile_dir = ensure_profile_dir(profile_name)
     host = extract_host(url)
     if not host:
@@ -239,7 +382,7 @@ async def run_session(
     return 0
 
 
-def main() -> None:
+def main() -> int:
     parser = argparse.ArgumentParser(
         description="Camoufox persistent session manager (profile-based)"
     )
@@ -273,12 +416,18 @@ def main() -> None:
         action="store_true",
         help="Show session status for URL",
     )
+    parser.add_argument(
+        "--runtime",
+        choices=("auto", "legacy"),
+        default="auto",
+        help=argparse.SUPPRESS,
+    )
 
     args = parser.parse_args()
 
     if args.login and args.headless:
         print("Error: --login and --headless are mutually exclusive")
-        sys.exit(2)
+        return 2
 
     export_path = Path(args.export_cookies).expanduser() if args.export_cookies else None
     import_path = Path(args.import_cookies).expanduser() if args.import_cookies else None
@@ -287,8 +436,30 @@ def main() -> None:
     if args.login:
         headless = False
 
-    exit_code = asyncio.run(
-        run_session(
+    try:
+        if args.runtime == "legacy":
+            return asyncio.run(
+                run_session(
+                    url=args.url,
+                    profile_name=args.profile,
+                    login_mode=args.login,
+                    headless=headless,
+                    export_cookies=export_path,
+                    import_cookies=import_path,
+                    status_only=args.status,
+                )
+            )
+
+        selection = detect_browser_runtime()
+        runtime = selection.runtime
+        if runtime is None:
+            return print_runtime_error(selection.error_message or "No supported browser runtime found.")
+
+        if runtime.kind == "distrobox":
+            return run_distrobox_fallback(Path(__file__).resolve(), sys.argv[1:], runtime)
+
+        return run_session_host_native(
+            runtime=runtime,
             url=args.url,
             profile_name=args.profile,
             login_mode=args.login,
@@ -297,9 +468,11 @@ def main() -> None:
             import_cookies=import_path,
             status_only=args.status,
         )
-    )
-    sys.exit(exit_code)
+    except ImportError:
+        return print_runtime_error("camoufox not installed in the selected legacy runtime.")
+    except BrowserRuntimeError as exc:
+        return print_runtime_error(str(exc))
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/runtime_support.py
+++ b/scripts/runtime_support.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Shared runtime detection and subprocess helpers for stealth-browser scripts."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+
+DEFAULT_DISTROBOX_CONTAINER = "pybox"
+DEFAULT_DISTROBOX_PYTHON = "python3.14"
+
+
+@dataclass(frozen=True)
+class BrowserRuntime:
+    kind: str
+    binary: str
+
+
+@dataclass(frozen=True)
+class RuntimeSelection:
+    runtime: BrowserRuntime | None
+    error_message: str | None = None
+
+
+class BrowserRuntimeError(RuntimeError):
+    """Raised when runtime selection or invocation fails."""
+
+
+def _resolve_binary(binary_name: str, env_var: str) -> str | None:
+    override = os.environ.get(env_var)
+    if override:
+        if override.lower() in {"none", "disabled"}:
+            return None
+        return override
+    return shutil.which(binary_name)
+
+
+def _pybox_available(distrobox_binary: str) -> bool:
+    try:
+        result = subprocess.run(
+            [distrobox_binary, "list"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return False
+    if result.returncode != 0:
+        return False
+    return DEFAULT_DISTROBOX_CONTAINER in result.stdout
+
+
+def find_host_native_runtime() -> BrowserRuntime | None:
+    binary = _resolve_binary("camoufox-nixos", "STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN")
+    if not binary:
+        return None
+    return BrowserRuntime(kind="host-native", binary=binary)
+
+
+def find_distrobox_runtime() -> BrowserRuntime | None:
+    binary = _resolve_binary("distrobox", "STEALTH_BROWSER_DISTROBOX_BIN")
+    if not binary:
+        return None
+    if not _pybox_available(binary):
+        return None
+    return BrowserRuntime(kind="distrobox", binary=binary)
+
+
+def detect_browser_runtime() -> RuntimeSelection:
+    host_native = find_host_native_runtime()
+    if host_native is not None:
+        return RuntimeSelection(runtime=host_native)
+
+    distrobox = find_distrobox_runtime()
+    if distrobox is not None:
+        return RuntimeSelection(runtime=distrobox)
+
+    return RuntimeSelection(
+        runtime=None,
+        error_message=(
+            "No supported browser runtime found. Install `camoufox-nixos` for the "
+            "NixOS-native path, or install `distrobox` with a `pybox` container "
+            "for the legacy fallback."
+        ),
+    )
+
+
+def run_camoufox_nixos(
+    runtime: BrowserRuntime,
+    args: Sequence[str],
+    extra_env: Mapping[str, str] | None = None,
+) -> dict:
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    try:
+        result = subprocess.run(
+            [runtime.binary, *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+    except FileNotFoundError as exc:
+        raise BrowserRuntimeError(
+            f"camoufox-nixos binary not found: {runtime.binary}"
+        ) from exc
+    stdout = result.stdout.strip()
+    stderr = result.stderr.strip()
+    if not stdout:
+        raise BrowserRuntimeError(stderr or "camoufox-nixos returned no JSON output.")
+
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise BrowserRuntimeError(
+            f"camoufox-nixos returned non-JSON output: {stdout}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise BrowserRuntimeError("camoufox-nixos returned an invalid JSON payload.")
+
+    payload["_exitCode"] = result.returncode
+    payload["_stderr"] = stderr
+    return payload
+
+
+def payload_error_message(payload: dict, default: str) -> str:
+    error = payload.get("error")
+    if isinstance(error, dict):
+        message = error.get("message")
+        if isinstance(message, str) and message:
+            return message
+    stderr = payload.get("_stderr")
+    if isinstance(stderr, str) and stderr:
+        return stderr
+    return default
+
+
+def require_ok(payload: dict, default: str) -> dict:
+    if payload.get("ok") is True:
+        return payload
+    raise BrowserRuntimeError(payload_error_message(payload, default))
+
+
+def run_distrobox_fallback(script_path: Path, argv: Sequence[str], runtime: BrowserRuntime) -> int:
+    command = [
+        runtime.binary,
+        "enter",
+        DEFAULT_DISTROBOX_CONTAINER,
+        "--",
+        DEFAULT_DISTROBOX_PYTHON,
+        str(script_path),
+        "--runtime",
+        "legacy",
+        *argv,
+    ]
+    try:
+        result = subprocess.run(command, check=False)
+    except FileNotFoundError as exc:
+        raise BrowserRuntimeError(
+            f"distrobox binary not found: {runtime.binary}"
+        ) from exc
+    return result.returncode

--- a/scripts/runtime_support.py
+++ b/scripts/runtime_support.py
@@ -149,7 +149,26 @@ def require_ok(payload: dict, default: str) -> dict:
     raise BrowserRuntimeError(payload_error_message(payload, default))
 
 
+def _strip_runtime_args(argv: Sequence[str]) -> list[str]:
+    sanitized: list[str] = []
+    skip_next = False
+
+    for arg in argv:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg == "--runtime":
+            skip_next = True
+            continue
+        if arg.startswith("--runtime="):
+            continue
+        sanitized.append(arg)
+
+    return sanitized
+
+
 def run_distrobox_fallback(script_path: Path, argv: Sequence[str], runtime: BrowserRuntime) -> int:
+    sanitized_argv = _strip_runtime_args(argv)
     command = [
         runtime.binary,
         "enter",
@@ -159,7 +178,7 @@ def run_distrobox_fallback(script_path: Path, argv: Sequence[str], runtime: Brow
         str(script_path),
         "--runtime",
         "legacy",
-        *argv,
+        *sanitized_argv,
     ]
     try:
         result = subprocess.run(command, check=False)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,39 +1,66 @@
-#!/bin/bash
-# Setup stealth browser tools in pybox
-# Usage: bash scripts/setup.sh
+#!/usr/bin/env bash
+set -euo pipefail
 
-set -e
+echo "🥷 Checking stealth browser runtimes..."
+echo ""
 
-echo "🥷 Setting up stealth browser tools in pybox..."
+have_host_native=0
+have_distrobox=0
 
-# Check if distrobox is available
-if ! command -v distrobox &> /dev/null; then
-    echo "❌ Error: distrobox not found. Install it first."
-    exit 1
+if command -v camoufox-nixos >/dev/null 2>&1; then
+  have_host_native=1
+  echo "✅ Browser lane ready: camoufox-nixos detected"
+else
+  echo "ℹ️  camoufox-nixos not found"
 fi
 
-# Check if pybox exists
-if ! distrobox list | grep -q "pybox"; then
-    echo "❌ Error: pybox container not found."
+if command -v distrobox >/dev/null 2>&1; then
+  if distrobox list | grep -q "pybox"; then
+    have_distrobox=1
+    echo "✅ Legacy fallback available: distrobox + pybox detected"
+    echo "📦 Installing fallback/API packages in pybox..."
+    distrobox enter pybox -- python3.14 -m pip install --upgrade pip
+    distrobox enter pybox -- python3.14 -m pip install camoufox curl_cffi
+    echo "🦊 Installing Camoufox browser in pybox..."
+    distrobox enter pybox -- python3.14 -c "import camoufox; camoufox.install()"
+    echo "🔧 Installing optional headed-browser deps in pybox..."
+    distrobox enter pybox -- sudo dnf install -y gtk3 libXt nss at-spi2-atk cups-libs libdrm mesa-libgbm 2>/dev/null || true
+  else
+    echo "ℹ️  distrobox is installed but pybox is missing"
     echo "   Create it with: distrobox create --name pybox --image fedora:latest"
-    exit 1
+  fi
+else
+  echo "ℹ️  distrobox not found"
 fi
 
-echo "📦 Installing Python packages..."
-distrobox-enter pybox -- pip install --upgrade pip
-distrobox-enter pybox -- pip install camoufox curl_cffi
+echo ""
 
-echo "🦊 Installing Camoufox browser..."
-distrobox-enter pybox -- python -c "import camoufox; camoufox.install()"
+if [[ "$have_host_native" -eq 0 && "$have_distrobox" -eq 0 ]]; then
+  echo "❌ No supported runtime is ready."
+  echo "   Browser default: install camoufox-nixos"
+  echo "   Fallback/API lane: install distrobox and create pybox, then rerun this script"
+  exit 1
+fi
 
-echo "🔧 Installing system dependencies for headed mode..."
-distrobox-enter pybox -- sudo dnf install -y gtk3 libXt nss at-spi2-atk cups-libs libdrm mesa-libgbm 2>/dev/null || true
+echo "Runtime summary:"
+if [[ "$have_host_native" -eq 1 ]]; then
+  echo "  - Browser default: camoufox-nixos"
+fi
+if [[ "$have_distrobox" -eq 1 ]]; then
+  echo "  - Browser fallback: distrobox + pybox"
+  echo "  - API lane: curl_cffi in distrobox + pybox"
+fi
 
 echo ""
-echo "✅ Setup complete!"
+echo "Try browser fetch with:"
+echo "  python scripts/camoufox-fetch.py https://example.com --headless"
 echo ""
-echo "Test with:"
-echo "  distrobox-enter pybox -- python scripts/nodriver-fetch.py https://bot.sannysoft.com --screenshot test.png"
+echo "Try session status with:"
+echo "  python scripts/camoufox-session.py --profile demo --status https://example.com"
 echo ""
-echo "Or for maximum stealth:"
-echo "  distrobox-enter pybox -- python scripts/camoufox-fetch.py https://nowsecure.nl --screenshot test.png"
+if [[ "$have_distrobox" -eq 1 ]]; then
+  echo "Try the API lane with:"
+  echo "  distrobox enter pybox -- python3.14 scripts/curl-api.py https://api.example.com"
+  echo ""
+fi
+echo "✅ Setup guidance complete"

--- a/tests/camoufox-fetch-adapter.sh
+++ b/tests/camoufox-fetch-adapter.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURES="$ROOT/tests/fixtures"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+export STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN="$FIXTURES/fake_camoufox_nixos.py"
+export STEALTH_BROWSER_DISTROBOX_BIN=none
+
+HTML_OUT="$TMPDIR/page.html"
+SHOT_OUT="$TMPDIR/page.png"
+STDOUT_OUT="$TMPDIR/fetch.stdout"
+
+python3 "$ROOT/scripts/camoufox-fetch.py" \
+  "https://example.com" \
+  --wait 0 \
+  --output "$HTML_OUT" \
+  --screenshot "$SHOT_OUT" \
+  --headless >"$STDOUT_OUT"
+
+grep -q "NixOS-native runtime" "$STDOUT_OUT"
+grep -q "HTML saved" "$STDOUT_OUT"
+grep -q "Example Domain" "$HTML_OUT"
+test -s "$SHOT_OUT"
+
+export STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN=none
+export STEALTH_BROWSER_DISTROBOX_BIN="$FIXTURES/fake_distrobox.sh"
+export FAKE_DISTROBOX_EXEC_TEXT="fetch fallback"
+export FAKE_DISTROBOX_LOG="$TMPDIR/distrobox.log"
+
+python3 "$ROOT/scripts/camoufox-fetch.py" "https://example.com" --wait 0 >"$TMPDIR/fallback.stdout"
+
+grep -q "FAKE DISTROBOX EXEC fetch fallback" "$TMPDIR/fallback.stdout"
+grep -q -- "--runtime legacy" "$TMPDIR/distrobox.log"
+
+echo "camoufox-fetch adapter checks passed"

--- a/tests/camoufox-fetch-adapter.sh
+++ b/tests/camoufox-fetch-adapter.sh
@@ -35,4 +35,16 @@ python3 "$ROOT/scripts/camoufox-fetch.py" "https://example.com" --wait 0 >"$TMPD
 grep -q "FAKE DISTROBOX EXEC fetch fallback" "$TMPDIR/fallback.stdout"
 grep -q -- "--runtime legacy" "$TMPDIR/distrobox.log"
 
+python3 "$ROOT/scripts/camoufox-fetch.py" \
+  "https://example.com" \
+  --wait 0 \
+  --runtime auto >"$TMPDIR/fallback-explicit-runtime.stdout"
+
+grep -q "FAKE DISTROBOX EXEC fetch fallback" "$TMPDIR/fallback-explicit-runtime.stdout"
+grep -q -- "--runtime legacy https://example.com --wait 0" "$TMPDIR/distrobox.log"
+if grep -q -- "--runtime auto" "$TMPDIR/distrobox.log"; then
+  echo "unexpected runtime auto flag leaked into distrobox fallback" >&2
+  exit 1
+fi
+
 echo "camoufox-fetch adapter checks passed"

--- a/tests/camoufox-session-adapter.sh
+++ b/tests/camoufox-session-adapter.sh
@@ -52,4 +52,17 @@ python3 "$ROOT/scripts/camoufox-session.py" \
 grep -q "FAKE DISTROBOX EXEC session fallback" "$TMPDIR/fallback.stdout"
 grep -q -- "--runtime legacy" "$TMPDIR/session-distrobox.log"
 
+python3 "$ROOT/scripts/camoufox-session.py" \
+  --profile smoke \
+  --status \
+  --runtime auto \
+  "https://example.com" >"$TMPDIR/fallback-explicit-runtime.stdout"
+
+grep -q "FAKE DISTROBOX EXEC session fallback" "$TMPDIR/fallback-explicit-runtime.stdout"
+grep -q -- "--runtime legacy --profile smoke --status https://example.com" "$TMPDIR/session-distrobox.log"
+if grep -q -- "--runtime auto" "$TMPDIR/session-distrobox.log"; then
+  echo "unexpected runtime auto flag leaked into distrobox fallback" >&2
+  exit 1
+fi
+
 echo "camoufox-session adapter checks passed"

--- a/tests/camoufox-session-adapter.sh
+++ b/tests/camoufox-session-adapter.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURES="$ROOT/tests/fixtures"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+export STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN="$FIXTURES/fake_camoufox_nixos.py"
+export STEALTH_BROWSER_DISTROBOX_BIN=none
+
+STATUS_OUT="$TMPDIR/status.stdout"
+python3 "$ROOT/scripts/camoufox-session.py" \
+  --profile smoke \
+  --status \
+  "https://example.com" >"$STATUS_OUT"
+
+grep -q "Profile: smoke" "$STATUS_OUT"
+grep -q "Stored cookies for example.com: 1" "$STATUS_OUT"
+
+EXPORT_PATH="$TMPDIR/cookies.json"
+python3 "$ROOT/scripts/camoufox-session.py" \
+  --profile smoke \
+  --headless \
+  --export-cookies "$EXPORT_PATH" \
+  "https://example.com" >"$TMPDIR/export.stdout"
+
+grep -q "Exported 1 cookies" "$TMPDIR/export.stdout"
+grep -q '"domain": "example.com"' "$EXPORT_PATH"
+
+printf '[]\n' > "$TMPDIR/import.json"
+set +e
+python3 "$ROOT/scripts/camoufox-session.py" \
+  --profile smoke \
+  --import-cookies "$TMPDIR/import.json" \
+  "https://example.com" >"$TMPDIR/import.stdout" 2>"$TMPDIR/import.stderr"
+status=$?
+set -e
+test "$status" -eq 2
+grep -q "requires the legacy distrobox fallback" "$TMPDIR/import.stderr"
+
+export STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN=none
+export STEALTH_BROWSER_DISTROBOX_BIN="$FIXTURES/fake_distrobox.sh"
+export FAKE_DISTROBOX_EXEC_TEXT="session fallback"
+export FAKE_DISTROBOX_LOG="$TMPDIR/session-distrobox.log"
+
+python3 "$ROOT/scripts/camoufox-session.py" \
+  --profile smoke \
+  --status \
+  "https://example.com" >"$TMPDIR/fallback.stdout"
+
+grep -q "FAKE DISTROBOX EXEC session fallback" "$TMPDIR/fallback.stdout"
+grep -q -- "--runtime legacy" "$TMPDIR/session-distrobox.log"
+
+echo "camoufox-session adapter checks passed"

--- a/tests/fixtures/fake_camoufox_nixos.py
+++ b/tests/fixtures/fake_camoufox_nixos.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Stub camoufox-nixos command for adapter tests."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def payload(command: str, data: dict | None = None, page: dict | None = None) -> dict:
+    return {
+        "ok": True,
+        "command": command,
+        "profile": "stub-profile",
+        "sessionId": "sess_stub",
+        "page": page or {
+            "url": "https://example.com",
+            "title": "Example Domain",
+        },
+        "data": data or {},
+        "error": None,
+    }
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    if not args:
+        print(json.dumps({"ok": False, "command": "unknown", "data": {}, "error": {"message": "missing command"}}))
+        return 1
+
+    command = args[0]
+    if command == "open":
+        url = args[-1] if args else "https://example.com"
+        print(json.dumps(payload("open", data={"headless": "--headless" in args}, page={"url": url, "title": "Example Domain"})))
+        return 0
+
+    if command == "eval":
+        expression = args[-1]
+        if "document.documentElement.outerHTML" in expression:
+            result = "<html><head><title>Example Domain</title></head><body><div id='content'>fixture</div></body></html>"
+        elif "Boolean(document.querySelector" in expression:
+            result = False
+        else:
+            result = None
+        print(json.dumps(payload("eval", data={"result": result})))
+        return 0
+
+    if command == "screenshot":
+        output = Path(args[-1]).expanduser()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_bytes(b"stub image")
+        print(json.dumps(payload("screenshot", data={"output": str(output)})))
+        return 0
+
+    if command == "storage-state":
+        output = Path(args[-1]).expanduser()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(
+                {
+                    "cookies": [
+                        {
+                            "name": "sessionid",
+                            "value": "stub",
+                            "domain": "example.com",
+                        }
+                    ],
+                    "origins": [],
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        print(json.dumps(payload("storage-state", data={"output": str(output), "cookies": 1})))
+        return 0
+
+    if command == "close":
+        print(json.dumps(payload("close", data={"closed": True})))
+        return 0
+
+    print(json.dumps({"ok": False, "command": command, "data": {}, "error": {"message": f"unsupported {command}"}}))
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/fake_distrobox.sh
+++ b/tests/fixtures/fake_distrobox.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "list" ]]; then
+  if [[ "${FAKE_DISTROBOX_NO_PYBOX:-0}" == "1" ]]; then
+    echo "NAME | IMAGE"
+    exit 0
+  fi
+  echo "NAME | IMAGE"
+  echo "pybox | fedora:latest"
+  exit 0
+fi
+
+if [[ "${1:-}" == "enter" ]]; then
+  shift
+  if [[ "${1:-}" == "pybox" ]]; then
+    shift
+  fi
+  if [[ "${1:-}" == "--" ]]; then
+    shift
+  fi
+  printf '%s\n' "FAKE DISTROBOX EXEC ${FAKE_DISTROBOX_EXEC_TEXT:-legacy fallback}"
+  printf '%s\n' "$*" > "${FAKE_DISTROBOX_LOG:-/dev/null}"
+  exit 0
+fi
+
+echo "unsupported fake distrobox invocation: $*" >&2
+exit 1

--- a/tests/runtime-selection.sh
+++ b/tests/runtime-selection.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURES="$ROOT/tests/fixtures"
+
+export PYTHONPATH="$ROOT/scripts"
+export STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN="$FIXTURES/fake_camoufox_nixos.py"
+export STEALTH_BROWSER_DISTROBOX_BIN="$FIXTURES/fake_distrobox.sh"
+
+python3 - <<'PY'
+from runtime_support import detect_browser_runtime
+
+selection = detect_browser_runtime()
+assert selection.runtime is not None
+assert selection.runtime.kind == "host-native"
+PY
+
+export STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN=none
+
+python3 - <<'PY'
+from runtime_support import detect_browser_runtime
+
+selection = detect_browser_runtime()
+assert selection.runtime is not None
+assert selection.runtime.kind == "distrobox"
+PY
+
+export FAKE_DISTROBOX_NO_PYBOX=1
+
+python3 - <<'PY'
+from runtime_support import detect_browser_runtime
+
+selection = detect_browser_runtime()
+assert selection.runtime is None
+assert "camoufox-nixos" in selection.error_message
+PY
+
+echo "runtime selection checks passed"


### PR DESCRIPTION
## What

Default the skill's browser workflows to `camoufox-nixos` while keeping `distrobox` + `pybox` as the fallback lane.

This PR:
- adds a shared runtime helper for browser runtime detection and subprocess dispatch
- routes `scripts/camoufox-fetch.py` to `camoufox-nixos` first, then legacy distrobox fallback
- routes `scripts/camoufox-session.py` to `camoufox-nixos` first, with explicit fallback for legacy-only features like `--import-cookies`
- rewrites `SKILL.md`, `README.md`, and `scripts/setup.sh` so the repo documents the real runtime order instead of hard-requiring distrobox
- adds stub-based tests for runtime selection, fetch adapter behavior, session adapter behavior, and fallback routing

## Why

The host-native `camoufox-nixos` wrapper now exists specifically for agent-driven Camoufox browsing, but this skill was still hardcoded around `distrobox-enter pybox -- python3.14 ...`.

That made the default browser path inaccurate on NixOS hosts and forced callers toward the older container-first lane even when the host-native wrapper was available. This change makes the browser lane honest without throwing away the skill's existing high-level fetch and session UX.

## Tests

- `python3 -m py_compile scripts/runtime_support.py scripts/camoufox-fetch.py scripts/camoufox-session.py`
- `bash -n scripts/setup.sh`
- `bash tests/runtime-selection.sh`
- `bash tests/camoufox-fetch-adapter.sh`
- `bash tests/camoufox-session-adapter.sh`
- `python3 scripts/camoufox-fetch.py "https://example.com" --wait 0 --headless --output /tmp/.../page.html --screenshot /tmp/.../page.png`
- `python3 scripts/camoufox-session.py --profile smoke-real --status "https://example.com"`

## AI Assistance

Implemented with Codex. I used local host verification for the real `camoufox-nixos` smoke checks and stub-based tests for deterministic adapter coverage.
