### PR TITLE
refactor(skill): tighten stealth-browser packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Camoufox Stealth Browser 🦊
 
-Camoufox is the stealth-browser skill for sites that block standard automation.
+Camoufox is the browser-stealth skill for hostile sites that block standard automation.
 
-## What Changed
+## Primary Use
 
 Browser workflows are now:
 
 1. `camoufox-nixos` first on NixOS hosts that have it
 2. `distrobox` + `pybox` fallback on compatible Linux setups
 
-`curl_cffi` remains the separate API-only lane and still uses the legacy distrobox setup in this repo.
+This is the repo's primary promise. The `curl_cffi` helper still exists, but it is a secondary API-only lane rather than the main routing target.
 
 ## Browser Quick Start
 
@@ -27,7 +27,7 @@ The browser scripts self-detect runtime. You do not need to decide between host-
 
 If `camoufox-nixos` is already installed, the browser lane is ready.
 
-If it is missing, or if you also want the `curl_cffi` lane, run:
+If it is missing, or if you also want the optional API helper lane, run:
 
 ```bash
 bash scripts/setup.sh
@@ -43,21 +43,44 @@ That script configures the distrobox fallback when possible and tells you what i
 | Browser automation on other compatible Linux hosts | `distrobox` + `pybox` | none in this repo |
 | API-only scraping | `curl_cffi` in distrobox | none in this repo |
 
-## State
+## State Ownership
 
-Browser state depends on runtime:
+This skill owns no durable state. Browser state depends on the selected runtime:
 
 - `camoufox-nixos`: `~/.cache/camoufox-nixos`
 - legacy distrobox lane: `~/.stealth-browser/profiles/<name>/`
 
-## Notes
+## Gotchas
+
+Read [references/gotchas.md](references/gotchas.md) before assuming parity between the host-native browser lane and the legacy distrobox lane.
+
+## Secondary API Helper
 
 - `--export-cookies` still works.
 - `--import-cookies` is a legacy fallback feature.
+- `curl_cffi` stays available for API-only scraping, but it is not the main reason this skill exists.
 - This repo does not try to make `camoufox-nixos` a generic cross-platform install target.
+
+## Verification
+
+Skill/package checks:
+
+```bash
+bash scripts/lint-skill.sh
+bash scripts/test-discovery.sh
+```
+
+Browser adapter checks:
+
+```bash
+bash tests/runtime-selection.sh
+bash tests/camoufox-fetch-adapter.sh
+bash tests/camoufox-session-adapter.sh
+```
 
 ## Docs
 
 - [SKILL.md](SKILL.md) — full usage guide
+- [references/gotchas.md](references/gotchas.md) — recurring footguns and local assumptions
 - [references/proxy-setup.md](references/proxy-setup.md) — proxy guidance
 - [references/fingerprint-checks.md](references/fingerprint-checks.md) — anti-bot fingerprint categories

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: camoufox-stealth-browser
 homepage: https://github.com/kesslerio/camoufox-stealth-browser-clawhub-skill
-description: C++ level anti-bot browser automation using Camoufox (patched Firefox). Browser workflows prefer camoufox-nixos on NixOS hosts and fall back to distrobox plus pybox on compatible Linux setups. Use when standard Playwright or Selenium gets blocked by Cloudflare, Datadome, Airbnb, Yelp, or similar anti-bot systems. NOT for normal browser automation.
+description: Stealth browser automation with Camoufox for hostile sites that block standard Playwright or Selenium flows. Browser workflows prefer camoufox-nixos on NixOS hosts and fall back to distrobox plus pybox on compatible Linux setups. Use when Cloudflare, Datadome, Airbnb, Yelp, or similar anti-bot targets require persistent login and session reuse. Browser lane only; API helpers are secondary.
 metadata:
   openclaw:
     emoji: "🦊"
@@ -12,7 +12,7 @@ metadata:
 
 # Camoufox Stealth Browser 🦊
 
-Camoufox is the stealth lane for hostile sites. It patches Firefox at the browser level instead of bolting JavaScript tricks on top after launch.
+Camoufox is the hostile-site browser lane. Use it when standard Playwright or Selenium flows get blocked and you need a real stealth browser session rather than generic automation.
 
 ## Why Camoufox
 
@@ -31,7 +31,7 @@ The skill now uses this order for **browser** workflows:
 2. `distrobox` with `pybox`
 3. clear setup failure if neither exists
 
-`curl_cffi` is unchanged. It remains the API-only lane and still relies on the legacy distrobox setup in this repo.
+The repo still carries a separate `curl_cffi` helper, but it is not the primary routing target for this skill.
 
 ## Quick Start
 
@@ -47,7 +47,7 @@ python scripts/camoufox-session.py \
   --status "https://www.economist.com"
 ```
 
-### Legacy/API setup
+### Optional fallback/API setup
 
 If `camoufox-nixos` is missing, or if you need the `curl_cffi` lane, run:
 
@@ -63,6 +63,7 @@ That script configures the distrobox fallback when `pybox` is available and tell
 - The site shows Cloudflare challenge loops
 - You need persistent authenticated browsing for hostile or paywalled sites
 - You need actual stealth rather than generic browser automation
+- You need login/session reuse on a host that already has `camoufox-nixos`
 
 Do **not** use this skill for ordinary browsing or generic site testing. Use your normal browser automation tool for that.
 
@@ -98,28 +99,32 @@ python scripts/camoufox-session.py \
   --status "https://www.airbnb.com"
 ```
 
-## State Model
+## State Ownership
 
-Browser profile state now depends on the selected runtime:
+This skill owns **no durable state of its own**. Browser profile state belongs to the selected runtime:
 
 - **Host-native (`camoufox-nixos`)**: `~/.cache/camoufox-nixos`
 - **Legacy distrobox fallback**: `~/.stealth-browser/profiles/<name>/`
 
 Implications:
 
-- Persistent session reuse still works in both lanes.
+- Persistent session reuse still works in both lanes because the runtimes own their own profile/cache locations.
 - `--import-cookies` is a legacy fallback feature. If you ask for it without the distrobox lane, the script fails clearly instead of pretending parity.
 - `--export-cookies` continues to work.
 
-## `curl_cffi` Lane
+## Gotchas
 
-`curl_cffi` remains the API-only path. It is useful when:
+See [references/gotchas.md](references/gotchas.md) for the non-obvious footguns: browser lane vs API helper confusion, headed-login expectations, Linux-only fallback assumptions, and host-native state-path differences.
+
+## Secondary API Helper
+
+`curl_cffi` remains in this repo as a secondary API-only helper. It is useful when:
 
 - there is no browser interaction requirement
 - you already know the API endpoint
 - browser overhead would be wasted
 
-Current repo guidance for it is still the legacy distrobox path:
+It is not the primary skill contract. Current repo guidance for it is still the legacy distrobox path:
 
 ```bash
 distrobox enter pybox -- python3.14 scripts/curl-api.py "https://api.example.com"
@@ -131,7 +136,7 @@ distrobox enter pybox -- python3.14 scripts/curl-api.py "https://api.example.com
 - **Other Linux hosts**: use the distrobox fallback
 - **macOS / Windows**: `camoufox-nixos` is not the portability story; the repo’s portable browser guidance is still the distrobox fallback where available
 
-This skill does **not** try to teach every machine how to recreate `camoufox-nixos`. That wrapper is host-specific.
+This skill does **not** try to teach every machine how to recreate `camoufox-nixos`. That wrapper is host-specific, and the distrobox lane is the compatibility path where available.
 
 ## Proxy Reminder
 
@@ -163,5 +168,6 @@ Interactive login still needs a visible browser window regardless of runtime. If
 ## References
 
 - [README.md](README.md) — repo overview
+- [references/gotchas.md](references/gotchas.md) — recurring footguns and local assumptions
 - [references/proxy-setup.md](references/proxy-setup.md) — proxy guidance
 - [references/fingerprint-checks.md](references/fingerprint-checks.md) — anti-bot fingerprint categories

--- a/docs/plans/2026-04-19-001-refactor-stealth-browser-skillcraft-followup-plan.md
+++ b/docs/plans/2026-04-19-001-refactor-stealth-browser-skillcraft-followup-plan.md
@@ -1,0 +1,267 @@
+---
+title: refactor: tighten stealth-browser skill packaging after skillcraft audit
+type: refactor
+status: completed
+date: 2026-04-19
+---
+
+# refactor: tighten stealth-browser skill packaging after skillcraft audit
+
+## Overview
+
+Ship a focused follow-up PR that improves `shared/stealth-browser` as an OpenClaw skill without reworking the underlying runtime migration. The patch should tighten the skill contract around hostile-site browser automation, make state ownership and gotchas explicit, and add the missing skill-level validation scripts so the repo is stronger by skillcraft standards.
+
+## Problem Frame
+
+The recent NixOS-default migration fixed the runtime story, but the repo still has several skill-quality gaps. The current skill contract mixes the main browser-stealth job with a secondary `curl_cffi` API lane, the docs partially blur who owns browser state, the skill does not have a dedicated gotchas surface, and the repo lacks skill-level lint/discovery checks. Those are not runtime bugs; they are packaging and maintainability gaps that make the skill weaker to route, review, and evolve.
+
+This follow-up should stay narrow. It should improve the skill as a skill, not reopen the runtime migration. Browser runtime behavior should remain NixOS-first with distrobox fallback, and `curl-api.py` should remain in the repo unless implementation reveals a clean zero-risk split. The main job is to make the repo easier to discover, safer to interpret, and easier to validate.
+
+## Requirements Trace
+
+- R1. Tighten the primary skill contract so discovery centers on hostile-site browser automation rather than a mixed browser-plus-API story.
+- R2. Keep the repo as a single skill for now, but demote the `curl_cffi` lane from the primary skill promise to a clearly secondary or legacy adjunct.
+- R3. Make state ownership explicit: the skill itself is stateless, while wrapped runtimes own their profile/cache locations.
+- R4. Add concrete gotchas and assumption-breakers that correct likely operator or model mistakes.
+- R5. Add skill-level validation scripts covering packaging and discovery, not just runtime adapter behavior.
+- R6. Keep the patch scoped to a focused PR that does not redesign `camoufox-nixos`, replace `curl-api.py`, or change the core browser runtime order.
+
+## Scope Boundaries
+
+- Do not change the browser runtime order or reopen the NixOS-default migration.
+- Do not split `curl-api.py` into a separate skill in this PR.
+- Do not redesign the host-native `camoufox-nixos` contract.
+- Do not add new browser primitives or runtime features.
+- Do not replace the existing adapter tests for fetch/session/runtime selection.
+
+### Deferred to Separate Tasks
+
+- Extract `curl_cffi` into a sibling skill if future usage shows that the mixed repo structure still causes discovery confusion.
+- Add CI automation around skill-level validation if this repo gains a broader contributor workflow.
+- Revisit cross-platform packaging if macOS or Windows support becomes a real requirement rather than a documentation concern.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `SKILL.md` currently leads with a mixed browser-and-API story: it describes the browser lane accurately, but still gives substantial first-class space to the `curl_cffi` lane.
+- `README.md` repeats the same mixed framing, so repo discovery still points at two adjacent capabilities instead of one clearly primary job.
+- `scripts/curl-api.py` is a self-contained helper and does not currently need redesign; the problem is how prominently the skill advertises it.
+- `scripts/setup.sh` still teaches both browser and API setup, so it must be aligned carefully with any contract narrowing.
+- The repo has runtime adapter tests (`tests/runtime-selection.sh`, `tests/camoufox-fetch-adapter.sh`, `tests/camoufox-session-adapter.sh`) but no skill-level packaging checks such as `scripts/lint-skill.sh` or `scripts/test-discovery.sh`.
+- The repo has no local `AGENTS.md`, `CLAUDE.md`, or `docs/solutions/` archive, so this plan should stay grounded in the repo’s own structure and the recent migration work rather than expecting richer local process artifacts.
+
+### Institutional Learnings
+
+- The runtime migration intentionally kept one skill and one browser-default story. This follow-up should preserve that decision rather than splitting the repo under audit pressure.
+- The migration already chose to keep `curl_cffi` separate from the browser lane conceptually. The remaining gap is presentation and validation, not architecture.
+- The post-merge review found one real runtime bug and it was already fixed. The remaining issues are mostly contract clarity, scope boundaries, and contributor ergonomics.
+
+### External References
+
+- No external research was necessary. The work is about skill packaging quality inside a small local repo, and the relevant constraints are already visible in the current files and the recent migration history.
+
+## Key Technical Decisions
+
+- **Keep one skill, narrow the promise:** the PR should not split the repo, but it should make the primary discovery surface clearly about hostile-site browser automation.
+- **Demote, do not delete, the API lane:** `scripts/curl-api.py` stays available, but docs should present it as an adjunct helper rather than equal billing with the browser lane.
+- **Document state ownership honestly:** the skill should explicitly say it owns no durable state; the wrapped runtimes own their respective profile and cache directories.
+- **Add a dedicated gotchas surface:** concrete footguns belong in either a `references/gotchas.md` file or an equivalent focused section, not scattered only across troubleshooting prose.
+- **Add skill-level checks inside the repo:** this patch should add the expected validation scripts for lint/discovery so contributors can verify the skill contract directly.
+- **Do not change core browser behavior while tightening packaging:** the patch is successful only if it improves routing and maintainability without introducing runtime churn.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this PR split `curl_cffi` into a separate skill?
+  - No. Keep one skill for now and narrow the primary contract instead.
+- Should the patch touch runtime adapter code again?
+  - Only if needed for doc/validation alignment. Core runtime behavior is not the target.
+- Should gotchas live inline or in a dedicated reference?
+  - Use a dedicated reference if it keeps `SKILL.md` lean; otherwise add a clearly bounded gotchas section. The plan assumes a dedicated reference is the cleaner default.
+- Should discovery validation be purely manual?
+  - No. Add repo-local scripts so discovery expectations are testable like the adapter behavior already is.
+
+### Deferred to Implementation
+
+- Whether the dedicated gotchas surface is best named `references/gotchas.md`, `references/usage-gotchas.md`, or folded into `README.md` if a new file proves unnecessary.
+- Whether `scripts/test-discovery.sh` should validate a phrase fixture file, a small inline case matrix, or both.
+- Whether `scripts/lint-skill.sh` should remain narrowly repo-specific or be shaped for reuse across neighboring skill repos.
+
+## Output Structure
+
+    SKILL.md
+    README.md
+    references/
+      gotchas.md
+    scripts/
+      lint-skill.sh
+      setup.sh
+      test-discovery.sh
+    tests/
+      discovery-cases.txt
+      runtime-selection.sh
+      camoufox-fetch-adapter.sh
+      camoufox-session-adapter.sh
+
+## Implementation Units
+
+- [x] **Unit 1: Add skill-level lint and discovery validation**
+
+**Goal:** Give contributors a direct way to validate the skill package itself, not just the runtime adapter scripts.
+
+**Requirements:** R5, R6
+
+**Dependencies:** None
+
+**Files:**
+- Create: `scripts/lint-skill.sh`
+- Create: `scripts/test-discovery.sh`
+- Create: `tests/discovery-cases.txt`
+- Modify: `README.md`
+- Modify: `SKILL.md`
+
+**Approach:**
+- Add a lightweight lint script that checks the skill packaging contract: frontmatter presence, required metadata, lean `SKILL.md` size, and existence of referenced support files that the docs depend on.
+- Add a discovery test script backed by a small curated set of expected trigger phrases and non-goal phrases so contributors can validate that the repo’s public description still points at the right category of work.
+- Document these scripts in the repo so future PRs can include them in verification output alongside the existing adapter tests.
+- Keep the scripts intentionally narrow and repo-specific; they should verify the promises this repo actually makes rather than inventing a generic skill framework.
+
+**Patterns to follow:**
+- Existing shell-based test style in `tests/*.sh`
+- Existing repo-local verification command style from the recent migration PR
+
+**Test scenarios:**
+- Happy path: `scripts/lint-skill.sh` passes when the skill frontmatter, referenced files, and expected packaging constraints are satisfied.
+- Edge case: the discovery cases include both positive phrases (stealth browser, blocked site, persistent login) and negative/non-primary phrases so over-broad descriptions are easier to catch.
+- Error path: the discovery script fails clearly when the primary contract drifts back toward a mixed or vague description.
+- Integration: repo documentation for verification includes both the skill-level checks and the existing adapter tests as complementary layers.
+
+**Verification:**
+- A contributor can validate discovery and packaging directly from the repo without relying only on informal manual review.
+
+- [x] **Unit 2: Narrow the primary skill contract and discovery surface**
+
+**Goal:** Make the skill easier for OpenClaw and operators to route correctly by centering the contract on hostile-site browser automation.
+
+**Requirements:** R1, R2, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `SKILL.md`
+- Modify: `README.md`
+- Modify: `scripts/setup.sh`
+- Test: `scripts/lint-skill.sh`
+- Test: `scripts/test-discovery.sh`
+- Test: `tests/discovery-cases.txt`
+
+**Approach:**
+- Tighten the frontmatter description in `SKILL.md` so the primary trigger language emphasizes hostile-site browser automation, login/session reuse, and anti-bot browsing rather than a mixed browser-plus-API capability.
+- Reframe `README.md` so browser workflows remain the headline use case and the `curl_cffi` lane is described as a secondary helper or legacy adjunct, not a co-equal promise.
+- Keep `scripts/setup.sh` aligned with the same framing: browser runtime first, API helper lane second, with no language that implies the skill’s main job is broader than it is.
+- Preserve the single-skill decision by explicitly describing the API lane as “still present, not primary” instead of pretending it does not exist.
+
+**Patterns to follow:**
+- Current top-level skill docs structure in `SKILL.md` and `README.md`
+- Existing runtime precedence language already established by the migration
+
+**Test scenarios:**
+- Happy path: the `SKILL.md` description clearly matches requests about blocked browser automation, hostile sites, login reuse, or stealth browsing.
+- Edge case: the docs still mention `curl_cffi`, but in a secondary role that does not overshadow the primary browser-stealth contract.
+- Error path: setup guidance does not imply that installing the API lane alone satisfies the main browser skill promise.
+- Integration: `SKILL.md`, `README.md`, and `scripts/setup.sh` tell the same high-level story about what this skill primarily does.
+
+**Verification:**
+- A reader scanning only the frontmatter description and opening sections understands that this is primarily a browser-stealth skill, with `curl_cffi` as a secondary adjunct.
+
+- [x] **Unit 3: Add explicit state-ownership and gotchas guidance**
+
+**Goal:** Remove ambiguity about who owns browser state and surface the non-obvious footguns in one place.
+
+**Requirements:** R3, R4, R6
+
+**Dependencies:** Units 1-2
+
+**Files:**
+- Modify: `SKILL.md`
+- Modify: `README.md`
+- Create: `references/gotchas.md`
+- Test: `scripts/lint-skill.sh`
+
+**Approach:**
+- Rewrite the state sections so they explicitly distinguish between skill-owned state and runtime-owned state: the skill owns no durable state, while `camoufox-nixos` and the legacy distrobox lane own their respective profile/cache locations.
+- Add a focused gotchas reference covering the mistakes most likely to recur: browser lane vs API lane confusion, headed login requirements, Linux-only fallback assumptions, host-native state location expectations, and legacy-only features such as cookie import behavior.
+- Link that gotchas reference from both `SKILL.md` and `README.md` so the information is easy to find without bloating the main skill body.
+
+**Patterns to follow:**
+- Existing troubleshooting style in `SKILL.md`
+- Existing focused references pattern under `references/`
+
+**Test scenarios:**
+- Happy path: the docs make it clear that runtime-owned profile/cache paths are not skill-owned state.
+- Edge case: a reader can distinguish “browser state persists” from “the skill persists its own state.”
+- Error path: gotchas explicitly warn against assuming macOS/Windows portability or assuming old profile-path semantics on the host-native lane.
+- Integration: the gotchas and state sections reinforce, rather than contradict, the narrower browser-first contract from Unit 1.
+
+**Verification:**
+- The repo has one clear answer to “where does state live?” and one dedicated place where recurring non-obvious mistakes are documented.
+
+- [x] **Unit 4: Align legacy API helper messaging with the tightened skill boundary**
+
+**Goal:** Keep the repo honest about `curl-api.py` without turning it into a first-class routing signal for the skill.
+
+**Requirements:** R2, R6
+
+**Dependencies:** Units 1-3
+
+**Files:**
+- Modify: `README.md`
+- Modify: `SKILL.md`
+- Modify: `scripts/setup.sh`
+- Test: `scripts/lint-skill.sh`
+- Test: `scripts/test-discovery.sh`
+
+**Approach:**
+- Move API-lane guidance into a clearly secondary section or appendix so it remains discoverable for contributors but does not dominate the main skill story.
+- Ensure setup guidance distinguishes “browser runtime readiness” from “optional API helper lane” so contributors do not conflate the two.
+
+**Patterns to follow:**
+- Current separation between browser scripts and `curl-api.py`
+- Current troubleshooting/notes structure in `README.md`
+
+**Test expectation:** none -- this unit is documentation and positioning work around an existing helper, not a behavioral feature change.
+
+**Verification:**
+- The API helper remains usable, but the repo no longer advertises it as part of the skill’s primary routing promise.
+
+## System-Wide Impact
+
+- **Interaction graph:** skill discovery text -> operator docs -> setup guidance -> browser scripts and secondary API helper.
+- **Error propagation:** packaging ambiguity today causes routing and expectation errors rather than runtime crashes; this patch should reduce those interpretation failures.
+- **State lifecycle risks:** unclear ownership of profile/cache locations leads operators to diagnose the wrong layer when persistence behaves unexpectedly.
+- **API surface parity:** browser runtime behavior should remain unchanged; this plan only narrows how the repo describes and validates itself.
+- **Integration coverage:** skill-level validation needs to coexist with the existing adapter tests so discovery, docs, and runtime behavior are covered together.
+- **Unchanged invariants:** the repo still supports NixOS-first browser automation with distrobox fallback, and `curl-api.py` remains available.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| The patch over-corrects and hides useful API helper documentation | Keep `curl_cffi` documented in a clearly secondary section instead of deleting it |
+| Discovery checks become brittle or gamed by wording churn | Keep the fixture set small, focused, and tied to clear routing intent rather than broad keyword matching |
+| Docs drift between `SKILL.md`, `README.md`, and `scripts/setup.sh` | Update all three surfaces in the same PR and validate them together in `scripts/lint-skill.sh` |
+| Packaging cleanup accidentally reopens runtime behavior | Keep runtime adapter code changes out of scope unless strictly needed for doc/help-text alignment |
+
+## Documentation / Operational Notes
+
+- This should land as one focused PR after the merged runtime migration, not as part of another runtime change.
+- The PR description should explicitly frame the work as “skill packaging quality follow-up” rather than a feature or runtime migration.
+- Verification in the PR should include both new skill-level checks and the existing adapter tests so reviewers can see the packaging/runtime split clearly.
+
+## Sources & References
+
+- Related code: `SKILL.md`, `README.md`, `scripts/setup.sh`, `scripts/curl-api.py`
+- Existing runtime validation: `tests/runtime-selection.sh`, `tests/camoufox-fetch-adapter.sh`, `tests/camoufox-session-adapter.sh`
+- Related merged work: PR `#9`

--- a/references/gotchas.md
+++ b/references/gotchas.md
@@ -1,0 +1,34 @@
+# Gotchas
+
+These are the recurring footguns for this repo. They matter more than generic advice.
+
+## Browser Lane Vs API Helper
+
+- The primary skill contract is hostile-site browser automation.
+- `curl_cffi` is still present, but it is a secondary API-only helper.
+- If the task needs login, session reuse, page interaction, or anti-bot browser behavior, use the browser lane, not `curl-api.py`.
+
+## State Ownership
+
+- This skill owns no durable state.
+- `camoufox-nixos` owns host-native browser state under `~/.cache/camoufox-nixos`.
+- The legacy distrobox browser lane owns its own profile state under `~/.stealth-browser/profiles/<name>/`.
+- Do not treat those runtime-owned directories as skill-managed state.
+
+## Headed Login Expectations
+
+- Interactive login still needs a visible browser window.
+- `--login` is for headed manual session establishment, not headless auth magic.
+- If you are remote, you still need a display-capable setup such as a local desktop session, forwarding that actually works, or VNC.
+
+## Fallback Assumptions
+
+- The distrobox lane is a Linux compatibility path, not a universal cross-platform story.
+- `camoufox-nixos` is host-specific. This repo does not explain how to recreate it on macOS or Windows.
+- If neither `camoufox-nixos` nor distrobox + `pybox` exists, browser workflows should fail clearly instead of guessing.
+
+## Legacy-Only Features
+
+- `--import-cookies` is a legacy fallback feature.
+- Do not assume the host-native browser lane can honestly reproduce every old distrobox-era storage trick.
+- `--export-cookies` still works, but the storage model is different between runtimes.

--- a/scripts/lint-skill.sh
+++ b/scripts/lint-skill.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILL="$ROOT/SKILL.md"
+README="$ROOT/README.md"
+
+test -f "$SKILL"
+test -f "$README"
+test -f "$ROOT/references/gotchas.md"
+test -f "$ROOT/scripts/test-discovery.sh"
+test -f "$ROOT/tests/discovery-cases.txt"
+
+skill_lines="$(wc -l < "$SKILL" | tr -d ' ')"
+if [[ "$skill_lines" -ge 500 ]]; then
+  echo "SKILL.md too long: ${skill_lines} lines" >&2
+  exit 1
+fi
+
+python3 - "$ROOT" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+root = Path(sys.argv[1])
+skill = root / "SKILL.md"
+readme = root / "README.md"
+
+skill_text = skill.read_text(encoding="utf-8")
+readme_text = readme.read_text(encoding="utf-8")
+
+required_frontmatter = [
+    r"(?m)^name:\s+camoufox-stealth-browser$",
+    r"(?m)^homepage:\s+https://github\.com/kesslerio/camoufox-stealth-browser-clawhub-skill$",
+    r"(?m)^description:\s+.+$",
+    r"(?m)^metadata:\s*$",
+    r'(?m)^\s+emoji:\s+"🦊"$',
+]
+
+for pattern in required_frontmatter:
+    if not re.search(pattern, skill_text):
+        raise SystemExit(f"missing required frontmatter pattern: {pattern}")
+
+local_targets = []
+for text, source in ((skill_text, "SKILL.md"), (readme_text, "README.md")):
+    for target in re.findall(r"\]\(([^)#]+)(?:#[^)]+)?\)", text):
+        if target.startswith("http://") or target.startswith("https://") or target.startswith("mailto:"):
+            continue
+        local_targets.append((source, target))
+
+missing = []
+for source, target in local_targets:
+    path = (root / target).resolve()
+    if not path.exists():
+        missing.append(f"{source} -> {target}")
+
+if missing:
+    raise SystemExit("missing referenced files:\n" + "\n".join(missing))
+PY
+
+test -x "$ROOT/scripts/test-discovery.sh"
+
+echo "skill lint passed"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "🥷 Checking stealth browser runtimes..."
+echo "🥷 Checking stealth browser skill runtimes..."
 echo ""
 
 have_host_native=0
@@ -9,7 +9,7 @@ have_distrobox=0
 
 if command -v camoufox-nixos >/dev/null 2>&1; then
   have_host_native=1
-  echo "✅ Browser lane ready: camoufox-nixos detected"
+  echo "✅ Primary browser lane ready: camoufox-nixos detected"
 else
   echo "ℹ️  camoufox-nixos not found"
 fi
@@ -17,8 +17,8 @@ fi
 if command -v distrobox >/dev/null 2>&1; then
   if distrobox list | grep -q "pybox"; then
     have_distrobox=1
-    echo "✅ Legacy fallback available: distrobox + pybox detected"
-    echo "📦 Installing fallback/API packages in pybox..."
+    echo "✅ Browser fallback available: distrobox + pybox detected"
+    echo "📦 Installing fallback browser lane and optional API helper packages in pybox..."
     distrobox enter pybox -- python3.14 -m pip install --upgrade pip
     distrobox enter pybox -- python3.14 -m pip install camoufox curl_cffi
     echo "🦊 Installing Camoufox browser in pybox..."
@@ -38,17 +38,17 @@ echo ""
 if [[ "$have_host_native" -eq 0 && "$have_distrobox" -eq 0 ]]; then
   echo "❌ No supported runtime is ready."
   echo "   Browser default: install camoufox-nixos"
-  echo "   Fallback/API lane: install distrobox and create pybox, then rerun this script"
+  echo "   Browser fallback and optional API helper lane: install distrobox and create pybox, then rerun this script"
   exit 1
 fi
 
 echo "Runtime summary:"
 if [[ "$have_host_native" -eq 1 ]]; then
-  echo "  - Browser default: camoufox-nixos"
+  echo "  - Primary browser lane: camoufox-nixos"
 fi
 if [[ "$have_distrobox" -eq 1 ]]; then
   echo "  - Browser fallback: distrobox + pybox"
-  echo "  - API lane: curl_cffi in distrobox + pybox"
+  echo "  - Optional API helper lane: curl_cffi in distrobox + pybox"
 fi
 
 echo ""
@@ -59,7 +59,7 @@ echo "Try session status with:"
 echo "  python scripts/camoufox-session.py --profile demo --status https://example.com"
 echo ""
 if [[ "$have_distrobox" -eq 1 ]]; then
-  echo "Try the API lane with:"
+  echo "Try the optional API helper lane with:"
   echo "  distrobox enter pybox -- python3.14 scripts/curl-api.py https://api.example.com"
   echo ""
 fi

--- a/scripts/test-discovery.sh
+++ b/scripts/test-discovery.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CASES="$ROOT/tests/discovery-cases.txt"
+
+python3 - "$ROOT" "$CASES" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+root = Path(sys.argv[1])
+cases_path = Path(sys.argv[2])
+skill_text = (root / "SKILL.md").read_text(encoding="utf-8")
+readme_text = (root / "README.md").read_text(encoding="utf-8")
+
+match = re.search(r"(?ms)^---\n(.*?)\n---", skill_text)
+if not match:
+    raise SystemExit("frontmatter not found in SKILL.md")
+
+description_match = re.search(r"(?m)^description:\s+(.+)$", match.group(1))
+if not description_match:
+    raise SystemExit("description not found in SKILL.md frontmatter")
+
+description = description_match.group(1).strip().lower()
+scopes = {
+    "description": description,
+    "skill": skill_text.lower(),
+    "readme": readme_text.lower(),
+}
+
+failures = []
+for raw_line in cases_path.read_text(encoding="utf-8").splitlines():
+    line = raw_line.strip()
+    if not line or line.startswith("#"):
+        continue
+    expectation, scope, label, terms = [part.strip() for part in line.split("|", 3)]
+    haystack = scopes[scope]
+    required_terms = [term.strip().lower() for term in terms.split(",") if term.strip()]
+    present = all(term in haystack for term in required_terms)
+    if expectation == "positive" and not present:
+        failures.append(f"missing expected discovery signal: {label}")
+    if expectation == "negative" and present:
+        failures.append(f"unexpected discovery signal present: {label}")
+
+if failures:
+    raise SystemExit("\n".join(failures))
+PY
+
+echo "discovery checks passed"

--- a/tests/discovery-cases.txt
+++ b/tests/discovery-cases.txt
@@ -1,0 +1,6 @@
+# expectation|scope|label|comma-separated terms
+positive|description|hostile-site browser automation|browser automation,block
+positive|description|stealth lane emphasis|camoufox,stealth
+positive|description|login and session reuse|login,session
+negative|description|api lane should not dominate|curl_cffi
+negative|description|api scraping should not route the skill|api scraping


### PR DESCRIPTION
## What

Tighten the `shared/stealth-browser` skill as a skill without changing its runtime behavior.

This PR:
- narrows the primary skill contract back to hostile-site browser automation
- keeps the `curl_cffi` lane available, but clearly demotes it to a secondary API helper
- makes state ownership explicit so the skill no longer reads like it owns browser profile storage
- adds a dedicated `references/gotchas.md` for recurring footguns
- adds `scripts/lint-skill.sh` and `scripts/test-discovery.sh` so contributors can validate packaging and discovery directly
- saves the follow-up implementation plan in `docs/plans/`

## Why

The NixOS-default runtime migration fixed the browser execution path, but the repo still had several skillcraft-level gaps:
- the skill contract still read like a mixed browser-plus-API product
- browser state ownership was easy to misread
- there was no dedicated gotchas surface
- the repo had runtime adapter tests, but no skill-level lint/discovery checks

This patch tightens the repo’s routing and contributor ergonomics without reopening the runtime migration.

## Tests

- `bash -n scripts/lint-skill.sh scripts/test-discovery.sh scripts/setup.sh`
- `bash scripts/lint-skill.sh`
- `bash scripts/test-discovery.sh`
- `bash tests/runtime-selection.sh`
- `bash tests/camoufox-fetch-adapter.sh`
- `bash tests/camoufox-session-adapter.sh`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This PR changes skill packaging, docs, and local validation scripts only; it does not alter deployed services or runtime automation behavior.

## AI Assistance

Implemented with Codex. I used the repo-local follow-up plan plus local verification of the new skill-level checks and the existing browser adapter tests.
