### PR TITLE
docs(skill): clarify wrapper runtime usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ This is the repo's primary promise. The `curl_cffi` helper still exists, but it 
 ## Browser Quick Start
 
 ```bash
-python scripts/camoufox-fetch.py "https://example.com" --headless
+./scripts/camoufox-fetch.py "https://example.com" --headless
 
-python scripts/camoufox-session.py \
+./scripts/camoufox-session.py \
   --profile example \
   --status "https://example.com"
 ```
 
-The browser scripts self-detect runtime. You do not need to decide between host-native and fallback manually.
+The browser scripts self-detect runtime. You do not need to decide between host-native and fallback manually, and you should not describe this as importing `camoufox` into system Python.
 
 ## Setup
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -49,6 +49,15 @@ The browser scripts self-detect runtime. Use them directly:
 
 Do not frame browser execution as "importing Camoufox into system Python" or "switching to the proper runtime." Run the wrapper scripts directly and let them choose the runtime.
 
+## Runtime Failure Reporting
+
+When browser execution fails, report the observed runtime failure first.
+
+- If `camoufox-nixos` times out or exits before navigation, say it failed before page navigation and treat it as a host runtime launch issue until proven otherwise.
+- Do not turn a wrapper startup failure into a target-site blocking diagnosis.
+- Do not claim a "legacy Python path worked" unless you actually ran that exact path and verified success.
+- If you suggest the distrobox fallback, present it as an alternate documented browser lane, not proof that system Python imports are the real problem.
+
 ### Optional fallback/API setup
 
 If `camoufox-nixos` is missing, or if you need the `curl_cffi` lane, run:
@@ -163,6 +172,7 @@ Interactive login still needs a visible browser window regardless of runtime. If
 | Problem | Meaning | What to do |
 |---------|---------|------------|
 | `No supported browser runtime found` | Neither `camoufox-nixos` nor valid distrobox fallback was detected | Install the host wrapper or configure distrobox plus pybox |
+| `camoufox-nixos` times out before navigation | Browser wrapper failed to launch cleanly on the host | Report it as a host runtime launch issue first; only discuss site blocking after the browser actually reaches the target |
 | `--import-cookies requires the legacy distrobox fallback` | Host-native lane cannot honestly reproduce that legacy import flow | Use the fallback lane for that operation |
 | Browser lane works but `curl-api.py` does not | `curl_cffi` lane is still legacy-path setup in this repo | Run `bash scripts/setup.sh` |
 | Immediate block or challenge loop | Proxy quality or behavior issue | Use residential/mobile proxy and increase wait time |

--- a/SKILL.md
+++ b/SKILL.md
@@ -40,12 +40,14 @@ The repo still carries a separate `curl_cffi` helper, but it is not the primary 
 The browser scripts self-detect runtime. Use them directly:
 
 ```bash
-python scripts/camoufox-fetch.py "https://example.com" --headless
+./scripts/camoufox-fetch.py "https://example.com" --headless
 
-python scripts/camoufox-session.py \
+./scripts/camoufox-session.py \
   --profile economist \
   --status "https://www.economist.com"
 ```
+
+Do not frame browser execution as "importing Camoufox into system Python" or "switching to the proper runtime." Run the wrapper scripts directly and let them choose the runtime.
 
 ### Optional fallback/API setup
 
@@ -72,7 +74,7 @@ Do **not** use this skill for ordinary browsing or generic site testing. Use you
 ### Protected-page fetch
 
 ```bash
-python scripts/camoufox-fetch.py \
+./scripts/camoufox-fetch.py \
   "https://www.yelp.com/biz/example" \
   --headless \
   --wait 8 \
@@ -84,17 +86,17 @@ python scripts/camoufox-fetch.py \
 
 ```bash
 # Interactive login
-python scripts/camoufox-session.py \
+./scripts/camoufox-session.py \
   --profile airbnb \
   --login "https://www.airbnb.com/account-settings"
 
 # Reuse saved session
-python scripts/camoufox-session.py \
+./scripts/camoufox-session.py \
   --profile airbnb \
   --headless "https://www.airbnb.com/trips"
 
 # Check session status
-python scripts/camoufox-session.py \
+./scripts/camoufox-session.py \
   --profile airbnb \
   --status "https://www.airbnb.com"
 ```
@@ -114,7 +116,7 @@ Implications:
 
 ## Gotchas
 
-See [references/gotchas.md](references/gotchas.md) for the non-obvious footguns: browser lane vs API helper confusion, headed-login expectations, Linux-only fallback assumptions, and host-native state-path differences.
+See [references/gotchas.md](references/gotchas.md) for the non-obvious footguns: runtime-framing mistakes, browser lane vs API helper confusion, headed-login expectations, Linux-only fallback assumptions, and host-native state-path differences.
 
 ## Secondary API Helper
 

--- a/references/gotchas.md
+++ b/references/gotchas.md
@@ -8,6 +8,9 @@ These are the recurring footguns for this repo. They matter more than generic ad
 - Do not narrate browser execution as "switching to the proper runtime."
 - Run `./scripts/camoufox-fetch.py` or `./scripts/camoufox-session.py` directly.
 - Those wrapper scripts detect `camoufox-nixos` first and fall back automatically when the legacy distrobox lane is valid.
+- If the wrapper fails before page navigation, describe that as an observed host runtime launch failure.
+- Do not infer that a legacy Python path worked unless you actually executed that exact path and verified success.
+- Do not jump from wrapper startup failure to "site blocking" until the browser really reached the target page.
 
 ## Browser Lane Vs API Helper
 

--- a/references/gotchas.md
+++ b/references/gotchas.md
@@ -2,6 +2,13 @@
 
 These are the recurring footguns for this repo. They matter more than generic advice.
 
+## Runtime Framing
+
+- Do not say the browser lane failed because system Python cannot import the `camoufox` module.
+- Do not narrate browser execution as "switching to the proper runtime."
+- Run `./scripts/camoufox-fetch.py` or `./scripts/camoufox-session.py` directly.
+- Those wrapper scripts detect `camoufox-nixos` first and fall back automatically when the legacy distrobox lane is valid.
+
 ## Browser Lane Vs API Helper
 
 - The primary skill contract is hostile-site browser automation.

--- a/scripts/camoufox-fetch.py
+++ b/scripts/camoufox-fetch.py
@@ -5,7 +5,7 @@ Maximum anti-bot evasion - C++ level Firefox patches.
 Best for: Yelp, Datadome, aggressive Cloudflare Turnstile.
 
 Usage:
-    python camoufox-fetch.py "https://example.com" [options]
+    ./scripts/camoufox-fetch.py "https://example.com" [options]
 
 Options:
     --wait N          Wait N seconds after page load (default: 8)

--- a/scripts/camoufox-session.py
+++ b/scripts/camoufox-session.py
@@ -3,7 +3,7 @@
 Camoufox persistent session manager.
 
 Usage:
-    python camoufox-session.py --profile NAME [--login|--headless] [--status]
+    ./scripts/camoufox-session.py --profile NAME [--login|--headless] [--status]
       [--import-cookies FILE] [--export-cookies FILE] URL
 """
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -53,10 +53,10 @@ fi
 
 echo ""
 echo "Try browser fetch with:"
-echo "  python scripts/camoufox-fetch.py https://example.com --headless"
+echo "  ./scripts/camoufox-fetch.py https://example.com --headless"
 echo ""
 echo "Try session status with:"
-echo "  python scripts/camoufox-session.py --profile demo --status https://example.com"
+echo "  ./scripts/camoufox-session.py --profile demo --status https://example.com"
 echo ""
 if [[ "$have_distrobox" -eq 1 ]]; then
   echo "Try the optional API helper lane with:"


### PR DESCRIPTION
## What
- switch browser-lane examples from `python scripts/...` to direct `./scripts/...` wrapper execution
- add explicit guidance that agents should not narrate Camoufox browser usage as importing into system Python or manually switching runtimes
- add runtime-failure reporting guidance so wrapper startup failures are described as observed host launch issues instead of speculative import-path or site-blocking explanations
- expand gotchas and troubleshooting to cover pre-navigation `camoufox-nixos` failures
- align the Python script usage docstrings with the same direct-wrapper contract

## Why
The previous wording nudged agents toward false explanations in two ways: it encouraged system-Python import stories, and it left wrapper startup failures underspecified enough that agents could invent a "legacy Python path worked" narrative without proving it. The correct contract is narrower: run the wrapper scripts directly, report observed runtime failures first, and only infer site blocking or alternate execution paths when they were actually verified. The script docstrings also needed the same update so code readers do not get stale guidance from the source files themselves.

## Tests
- `bash -n scripts/setup.sh`
- `python3 -m py_compile scripts/camoufox-fetch.py scripts/camoufox-session.py`
- `bash scripts/lint-skill.sh`
- `bash scripts/test-discovery.sh`
- `bash tests/runtime-selection.sh`

## AI Assistance
Authored with Codex.
