### PR TITLE
fix(runtime): prefer OpenClaw Camoufox bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ The browser scripts self-detect runtime. You do not need to decide between host-
 
 If `camoufox-nixos` is already installed, the browser lane is ready.
 
+If you patched the underlying NixOS wrapper, the live `camoufox-nixos` command does not update until you rebuild the host system:
+
+```bash
+sudo nixos-rebuild switch --flake /etc/nixos#nixos
+```
+
 If it is missing, or if you also want the optional API helper lane, run:
 
 ```bash
@@ -53,6 +59,8 @@ This skill owns no durable state. Browser state depends on the selected runtime:
 ## Gotchas
 
 Read [references/gotchas.md](references/gotchas.md) before assuming parity between the host-native browser lane and the legacy distrobox lane.
+
+On TTY-only or headless shell sessions, a headed host-native launch should return `display_missing`. That is expected; use `--headless` unless a real display session is attached.
 
 ## Secondary API Helper
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Camoufox is the browser-stealth skill for hostile sites that block standard auto
 
 Browser workflows are now:
 
-1. `camoufox-nixos` first on NixOS hosts that have it
-2. `distrobox` + `pybox` fallback on compatible Linux setups
+1. `/data/bin/camoufox-nixos` first inside OpenClaw/AlphaClaw when that bridge exists
+2. `camoufox-nixos` from `PATH` on NixOS hosts that have it
+3. `distrobox` + `pybox` fallback on compatible Linux setups
 
 This is the repo's primary promise. The `curl_cffi` helper still exists, but it is a secondary API-only lane rather than the main routing target.
 
@@ -22,6 +23,8 @@ This is the repo's primary promise. The `curl_cffi` helper still exists, but it 
 ```
 
 The browser scripts self-detect runtime. You do not need to decide between host-native and fallback manually, and you should not describe this as importing `camoufox` into system Python.
+
+Inside OpenClaw/AlphaClaw, do not force `/run/current-system/sw/bin/camoufox-nixos` unless you are deliberately testing the direct host wrapper. The supported production path is the `/data/bin/camoufox-nixos` bridge, which maps container state to the host runtime.
 
 ## Setup
 
@@ -45,6 +48,7 @@ That script configures the distrobox fallback when possible and tells you what i
 
 | Use case | Preferred lane | Fallback |
 |----------|----------------|----------|
+| Browser automation inside OpenClaw/AlphaClaw | `/data/bin/camoufox-nixos` bridge | `distrobox` + `pybox` |
 | Browser automation on NixOS host | `camoufox-nixos` | `distrobox` + `pybox` |
 | Browser automation on other compatible Linux hosts | `distrobox` + `pybox` | none in this repo |
 | API-only scraping | `curl_cffi` in distrobox | none in this repo |
@@ -54,6 +58,7 @@ That script configures the distrobox fallback when possible and tells you what i
 This skill owns no durable state. Browser state depends on the selected runtime:
 
 - `camoufox-nixos`: `~/.cache/camoufox-nixos`
+- OpenClaw/AlphaClaw bridge: host-side state mapped by `/data/bin/camoufox-nixos`
 - legacy distrobox lane: `~/.stealth-browser/profiles/<name>/`
 
 ## Gotchas

--- a/SKILL.md
+++ b/SKILL.md
@@ -68,6 +68,12 @@ bash scripts/setup.sh
 
 That script configures the distrobox fallback when `pybox` is available and tells you what is missing when it is not.
 
+If you just patched the host-local NixOS wrapper itself, remember that the live `camoufox-nixos` command does not change until the host runs:
+
+```bash
+sudo nixos-rebuild switch --flake /etc/nixos#nixos
+```
+
 ## When To Use
 
 - Standard Playwright or Selenium gets blocked
@@ -167,11 +173,14 @@ Interactive login still needs a visible browser window regardless of runtime. If
 - SSH with display forwarding where supported
 - VNC or similar remote desktop
 
+On TTY-only or headless shell sessions, headed `camoufox-nixos open` should fail fast with `display_missing`. That is expected. Use `--headless` unless you intentionally attached a real display.
+
 ## Troubleshooting
 
 | Problem | Meaning | What to do |
 |---------|---------|------------|
 | `No supported browser runtime found` | Neither `camoufox-nixos` nor valid distrobox fallback was detected | Install the host wrapper or configure distrobox plus pybox |
+| `display_missing` | You tried a headed host-native launch on a session with no `DISPLAY` or `WAYLAND_DISPLAY` | This is expected on TTY-only hosts and remote shells; rerun with `--headless` or use a real graphical session |
 | `camoufox-nixos` times out before navigation | Browser wrapper failed to launch cleanly on the host | Report it as a host runtime launch issue first; only discuss site blocking after the browser actually reaches the target |
 | `--import-cookies requires the legacy distrobox fallback` | Host-native lane cannot honestly reproduce that legacy import flow | Use the fallback lane for that operation |
 | Browser lane works but `curl-api.py` does not | `curl_cffi` lane is still legacy-path setup in this repo | Run `bash scripts/setup.sh` |

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: camoufox-stealth-browser
 homepage: https://github.com/kesslerio/camoufox-stealth-browser-clawhub-skill
-description: Stealth browser automation with Camoufox for hostile sites that block standard Playwright or Selenium flows. Browser workflows prefer camoufox-nixos on NixOS hosts and fall back to distrobox plus pybox on compatible Linux setups. Use when Cloudflare, Datadome, Airbnb, Yelp, or similar anti-bot targets require persistent login and session reuse. Browser lane only; API helpers are secondary.
+description: Explicit-only stealth browser automation with Camoufox for hostile sites that block native OpenClaw browser, standard Playwright, or Selenium flows. Default to the native OpenClaw browser for ordinary browsing, booking flows, calendars, forms, screenshots, and generic site testing. Use Camoufox only when the user explicitly asks for Camoufox, a stealth browser, bot bypass, anti-bot evasion, Cloudflare/Datadome bypass, persistent login/session reuse, or a target has already blocked the native browser lane. Browser lane only; API helpers are secondary.
 metadata:
   openclaw:
     emoji: "🦊"
@@ -12,7 +12,18 @@ metadata:
 
 # Camoufox Stealth Browser 🦊
 
-Camoufox is the hostile-site browser lane. Use it when standard Playwright or Selenium flows get blocked and you need a real stealth browser session rather than generic automation.
+Default browser lane: native OpenClaw browser.
+
+Do not use this skill for ordinary browser automation. Use native OpenClaw browser first for normal browsing, appointment booking, dynamic calendars, forms, screenshots, accessibility snapshots, and generic site testing.
+
+Use Camoufox only when one of these is true:
+
+- The user explicitly asks for Camoufox.
+- The user explicitly asks for a stealth browser, bot bypass, anti-bot evasion, Cloudflare bypass, Datadome bypass, or similar.
+- Native OpenClaw browser already reached the site and was blocked by anti-bot or fingerprinting defenses.
+- The task requires a persistent hostile-site stealth session and the user accepts that tradeoff.
+
+Camoufox is the hostile-site browser lane, not the default browser lane. If native OpenClaw browser is unavailable, report that directly instead of silently switching to Camoufox unless the user asked for stealth/bypass behavior.
 
 ## Why Camoufox
 
@@ -25,11 +36,14 @@ Camoufox is the hostile-site browser lane. Use it when standard Playwright or Se
 
 ## Runtime Selection
 
-The skill now uses this order for **browser** workflows:
+For explicit Camoufox workflows, the skill uses this order:
 
-1. `camoufox-nixos`
-2. `distrobox` with `pybox`
-3. clear setup failure if neither exists
+1. OpenClaw/AlphaClaw bridge at `/data/bin/camoufox-nixos`, when present
+2. `camoufox-nixos` from `PATH`
+3. `distrobox` with `pybox`
+4. clear setup failure if neither exists
+
+Inside OpenClaw/AlphaClaw, prefer `/data/bin/camoufox-nixos`. Do not override the scripts to use `/run/current-system/sw/bin/camoufox-nixos` unless you are deliberately diagnosing the direct host wrapper; in this environment that path can report misleading missing-venv errors such as `/data/.local/venvs/camoufox/bin/python`.
 
 The repo still carries a separate `curl_cffi` helper, but it is not the primary routing target for this skill.
 
@@ -82,7 +96,7 @@ sudo nixos-rebuild switch --flake /etc/nixos#nixos
 - You need actual stealth rather than generic browser automation
 - You need login/session reuse on a host that already has `camoufox-nixos`
 
-Do **not** use this skill for ordinary browsing or generic site testing. Use your normal browser automation tool for that.
+Do **not** use this skill for ordinary browsing or generic site testing. Use native OpenClaw browser for that.
 
 ## Workflow Summary
 
@@ -120,6 +134,7 @@ Do **not** use this skill for ordinary browsing or generic site testing. Use you
 
 This skill owns **no durable state of its own**. Browser profile state belongs to the selected runtime:
 
+- **OpenClaw/AlphaClaw bridge (`/data/bin/camoufox-nixos`)**: bridge-managed host state mapping
 - **Host-native (`camoufox-nixos`)**: `~/.cache/camoufox-nixos`
 - **Legacy distrobox fallback**: `~/.stealth-browser/profiles/<name>/`
 

--- a/docs/plans/2026-07-07-001-prefer-openclaw-camoufox-bridge.md
+++ b/docs/plans/2026-07-07-001-prefer-openclaw-camoufox-bridge.md
@@ -1,0 +1,116 @@
+---
+title: "Prefer OpenClaw Camoufox Bridge Runtime"
+created: 2026-07-07
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+---
+
+# Prefer OpenClaw Camoufox Bridge Runtime
+
+## Goal Capsule
+
+Fix the stealth-browser skill so OpenClaw/AlphaClaw Camoufox workflows prefer the working `/data/bin/camoufox-nixos` host bridge over the direct host `/run/current-system/sw/bin/camoufox-nixos` wrapper when both are visible. This prevents agents from diagnosing a missing `/data/.local/venvs/camoufox` runtime when the actual supported path is the bridge.
+
+## Product Contract
+
+Product Contract preservation: Product Contract unchanged.
+
+Requirements:
+
+- R1: Browser workflows that explicitly use Camoufox must select the OpenClaw bridge runtime first when `/data/bin/camoufox-nixos` is executable.
+- R2: Explicit `STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN` overrides must continue to win for tests and operator diagnostics, including `none` and `disabled`.
+- R3: Non-OpenClaw hosts must keep the existing behavior of using `camoufox-nixos` from `PATH`, then distrobox `pybox` fallback.
+- R4: Fetch/session scripts must not force temporary state in a way that breaks the OpenClaw bridge state mapping.
+- R5: Skill docs must explain the OpenClaw bridge path and warn against using `/run/current-system/sw/bin/camoufox-nixos` inside OpenClaw.
+
+Non-goals:
+
+- Do not make direct Camoufox launch inside AlphaClaw containers work.
+- Do not rebuild NixOS or create `/data/.local/venvs/camoufox`.
+- Do not change native OpenClaw Chromium browser behavior.
+
+## Existing Patterns
+
+- Runtime detection lives in `scripts/runtime_support.py`.
+- Fetch adapter behavior is covered by `tests/camoufox-fetch-adapter.sh`.
+- Runtime selection behavior is covered by `tests/runtime-selection.sh`.
+- Discovery/docs expectations are covered by `scripts/test-discovery.sh` and `tests/discovery-cases.txt`.
+- `SKILL.md` already distinguishes native OpenClaw browser from explicit Camoufox workflows.
+
+## Implementation Units
+
+### U1. Prefer Bridge Runtime
+
+Files:
+
+- `scripts/runtime_support.py`
+- `tests/runtime-selection.sh`
+
+Approach:
+
+- Add an OpenClaw bridge candidate before generic `shutil.which("camoufox-nixos")`.
+- Prefer `/data/bin/camoufox-nixos` only when it exists and is executable.
+- Preserve `STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN` as the highest-priority explicit override.
+- Keep `none` and `disabled` override behavior.
+
+Test scenarios:
+
+- With no override and an executable fake bridge path, runtime selection returns that bridge binary.
+- With an explicit override, runtime selection returns the override instead of the bridge.
+- With the override set to `none`, runtime selection skips host-native and falls back to distrobox.
+
+### U2. Preserve Bridge State Mapping
+
+Files:
+
+- `scripts/camoufox-fetch.py`
+- `scripts/camoufox-session.py`
+- `tests/camoufox-fetch-adapter.sh`
+- `tests/camoufox-session-adapter.sh`
+
+Approach:
+
+- Avoid forcing `CAMOUFOX_NIXOS_STATE_ROOT` for host-native runtime unless needed for an isolated non-bridge test path.
+- Let `/data/bin/camoufox-nixos` apply its own bridge defaults for container-to-host state mapping.
+- Keep cleanup behavior for sessions opened by the scripts.
+
+Test scenarios:
+
+- Fetch via a fake bridge receives no forced temporary `CAMOUFOX_NIXOS_STATE_ROOT`.
+- Fetch still writes HTML and screenshots through the host-native adapter.
+- Session adapter still opens, evaluates, and closes via fake runtime.
+
+### U3. Document OpenClaw Runtime Choice
+
+Files:
+
+- `SKILL.md`
+- `README.md`
+- `references/gotchas.md`
+- `tests/discovery-cases.txt`
+
+Approach:
+
+- Add concise OpenClaw-specific guidance: use `/data/bin/camoufox-nixos` bridge inside OpenClaw/AlphaClaw.
+- Explain that `/run/current-system/sw/bin/camoufox-nixos` may be a direct host wrapper and can report misleading missing-venv errors in this environment.
+- Keep the existing “native browser first, Camoufox only explicitly” guidance.
+
+Test scenarios:
+
+- Discovery checks still pass.
+- Docs contain the bridge guidance without making Camoufox look like the default browser lane.
+
+## Verification
+
+- `tests/runtime-selection.sh`
+- `tests/camoufox-fetch-adapter.sh`
+- `tests/camoufox-session-adapter.sh`
+- `scripts/test-discovery.sh`
+- Manual smoke: `PATH=/data/bin:$PATH ./scripts/camoufox-fetch.py https://example.com --headless --wait 0 --output /tmp/camoufox_fetch_bridge_test.html`
+
+## Risks
+
+- Over-preferring `/data/bin/camoufox-nixos` outside OpenClaw would be surprising if a developer happens to have that path mounted for another purpose. Limit preference to executable existence and preserve explicit override escape hatches.
+- Removing temporary state injection can affect tests that assumed isolation. Update fake-runtime tests to assert the intended bridge contract rather than relying on temp state.

--- a/references/gotchas.md
+++ b/references/gotchas.md
@@ -30,6 +30,12 @@ These are the recurring footguns for this repo. They matter more than generic ad
 - Interactive login still needs a visible browser window.
 - `--login` is for headed manual session establishment, not headless auth magic.
 - If you are remote, you still need a display-capable setup such as a local desktop session, forwarding that actually works, or VNC.
+- On TTY-only or headless shell sessions, a headed host-native launch should fail with `display_missing` instead of pretending the browser lane is broken.
+
+## NixOS Rebuilds
+
+- If you patch the host-local `camoufox-nixos` NixOS module, the live wrapper does not update until `sudo nixos-rebuild switch --flake /etc/nixos#nixos` completes.
+- Do not diagnose the old live wrapper before checking whether the rebuilt `/run/current-system/sw/bin/camoufox-nixos` actually points at the new store path.
 
 ## Fallback Assumptions
 

--- a/references/gotchas.md
+++ b/references/gotchas.md
@@ -7,10 +7,12 @@ These are the recurring footguns for this repo. They matter more than generic ad
 - Do not say the browser lane failed because system Python cannot import the `camoufox` module.
 - Do not narrate browser execution as "switching to the proper runtime."
 - Run `./scripts/camoufox-fetch.py` or `./scripts/camoufox-session.py` directly.
-- Those wrapper scripts detect `camoufox-nixos` first and fall back automatically when the legacy distrobox lane is valid.
+- Inside OpenClaw/AlphaClaw, those wrapper scripts prefer `/data/bin/camoufox-nixos`, the host bridge client.
+- Outside OpenClaw/AlphaClaw, those wrapper scripts detect `camoufox-nixos` from `PATH` first and fall back automatically when the legacy distrobox lane is valid.
 - If the wrapper fails before page navigation, describe that as an observed host runtime launch failure.
 - Do not infer that a legacy Python path worked unless you actually executed that exact path and verified success.
 - Do not jump from wrapper startup failure to "site blocking" until the browser really reached the target page.
+- Do not force `/run/current-system/sw/bin/camoufox-nixos` from OpenClaw unless you are deliberately diagnosing the direct host wrapper. It can bypass the bridge and produce misleading missing-venv errors such as `/data/.local/venvs/camoufox/bin/python`.
 
 ## Browser Lane Vs API Helper
 
@@ -21,6 +23,7 @@ These are the recurring footguns for this repo. They matter more than generic ad
 ## State Ownership
 
 - This skill owns no durable state.
+- The OpenClaw/AlphaClaw bridge owns state mapping through `/data/bin/camoufox-nixos`; scripts should not override it with a temporary `CAMOUFOX_NIXOS_STATE_ROOT`.
 - `camoufox-nixos` owns host-native browser state under `~/.cache/camoufox-nixos`.
 - The legacy distrobox browser lane owns its own profile state under `~/.stealth-browser/profiles/<name>/`.
 - Do not treat those runtime-owned directories as skill-managed state.

--- a/scripts/camoufox-fetch.py
+++ b/scripts/camoufox-fetch.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-import tempfile
 import time
 import uuid
 from pathlib import Path
@@ -128,72 +127,67 @@ def fetch_page_host_native(
 
     print("🥷 Starting Camoufox browser (NixOS-native runtime)...")
 
-    with tempfile.TemporaryDirectory(prefix="camoufox-fetch-") as state_root:
-        env = {"CAMOUFOX_NIXOS_STATE_ROOT": state_root}
-        profile = f"fetch-{uuid.uuid4().hex[:10]}"
-        open_args = ["open", "--profile", profile]
-        if headless:
-            open_args.append("--headless")
-        if proxy:
-            open_args.extend(["--proxy", proxy])
-        open_args.append(url)
+    profile = f"fetch-{uuid.uuid4().hex[:10]}"
+    open_args = ["open", "--profile", profile]
+    if headless:
+        open_args.append("--headless")
+    if proxy:
+        open_args.extend(["--proxy", proxy])
+    open_args.append(url)
 
-        open_payload = run_camoufox_nixos(runtime, open_args, extra_env=env)
-        require_ok(open_payload, "Failed to open browser session.")
-        session_id = open_payload.get("sessionId")
-        if not isinstance(session_id, str) or not session_id:
-            raise BrowserRuntimeError("camoufox-nixos did not return a session id.")
+    open_payload = run_camoufox_nixos(runtime, open_args)
+    require_ok(open_payload, "Failed to open browser session.")
+    session_id = open_payload.get("sessionId")
+    if not isinstance(session_id, str) or not session_id:
+        raise BrowserRuntimeError("camoufox-nixos did not return a session id.")
 
-        try:
-            print(f"📡 Navigating to: {url}")
-            print(f"⏳ Waiting {wait}s for anti-bot resolution...")
-            time.sleep(wait)
+    try:
+        print(f"📡 Navigating to: {url}")
+        print(f"⏳ Waiting {wait}s for anti-bot resolution...")
+        time.sleep(wait)
 
-            eval_payload = run_camoufox_nixos(
+        eval_payload = run_camoufox_nixos(
+            runtime,
+            ["eval", "--session", session_id, "document.documentElement.outerHTML"],
+        )
+        require_ok(eval_payload, "Failed to read page HTML.")
+        content = eval_payload.get("data", {}).get("result", "")
+        if not isinstance(content, str):
+            content = json.dumps(content)
+
+        page = eval_payload.get("page") or open_payload.get("page") or {}
+        title = page.get("title") or ""
+        final_url = page.get("url") or url
+        print(f"📄 Page title: {title}")
+        print_block_indicators(content)
+
+        if screenshot:
+            screenshot_path = str(Path(screenshot).expanduser())
+            screenshot_payload = run_camoufox_nixos(
                 runtime,
-                ["eval", "--session", session_id, "document.documentElement.outerHTML"],
-                extra_env=env,
+                ["screenshot", "--session", session_id, screenshot_path],
             )
-            require_ok(eval_payload, "Failed to read page HTML.")
-            content = eval_payload.get("data", {}).get("result", "")
-            if not isinstance(content, str):
-                content = json.dumps(content)
+            require_ok(screenshot_payload, "Failed to capture screenshot.")
+            print(f"📸 Screenshot saved: {screenshot_path}")
 
-            page = eval_payload.get("page") or open_payload.get("page") or {}
-            title = page.get("title") or ""
-            final_url = page.get("url") or url
-            print(f"📄 Page title: {title}")
-            print_block_indicators(content)
+        if output:
+            output_path = Path(output).expanduser()
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(content, encoding="utf-8")
+            print(f"💾 HTML saved: {output_path}")
+        else:
+            print(f"\n✅ Success! Page loaded ({len(content)} bytes)")
+            print(f"   Final URL: {final_url}")
 
-            if screenshot:
-                screenshot_path = str(Path(screenshot).expanduser())
-                screenshot_payload = run_camoufox_nixos(
-                    runtime,
-                    ["screenshot", "--session", session_id, screenshot_path],
-                    extra_env=env,
-                )
-                require_ok(screenshot_payload, "Failed to capture screenshot.")
-                print(f"📸 Screenshot saved: {screenshot_path}")
-
-            if output:
-                output_path = Path(output).expanduser()
-                output_path.parent.mkdir(parents=True, exist_ok=True)
-                output_path.write_text(content, encoding="utf-8")
-                print(f"💾 HTML saved: {output_path}")
-            else:
-                print(f"\n✅ Success! Page loaded ({len(content)} bytes)")
-                print(f"   Final URL: {final_url}")
-
-            return 0
-        finally:
-            close_payload = run_camoufox_nixos(
-                runtime,
-                ["close", "--session", session_id],
-                extra_env=env,
-            )
-            if close_payload.get("ok") is not True:
-                message = payload_error_message(close_payload, "Failed to close browser session.")
-                print(f"Warning: {message}", file=sys.stderr)
+        return 0
+    finally:
+        close_payload = run_camoufox_nixos(
+            runtime,
+            ["close", "--session", session_id],
+        )
+        if close_payload.get("ok") is not True:
+            message = payload_error_message(close_payload, "Failed to close browser session.")
+            print(f"Warning: {message}", file=sys.stderr)
 
 
 def main() -> int:

--- a/scripts/runtime_support.py
+++ b/scripts/runtime_support.py
@@ -14,6 +14,7 @@ from typing import Mapping, Sequence
 
 DEFAULT_DISTROBOX_CONTAINER = "pybox"
 DEFAULT_DISTROBOX_PYTHON = "python3.14"
+DEFAULT_OPENCLAW_CAMOUFOX_NIXOS = "/data/bin/camoufox-nixos"
 
 
 @dataclass(frozen=True)
@@ -32,13 +33,29 @@ class BrowserRuntimeError(RuntimeError):
     """Raised when runtime selection or invocation fails."""
 
 
+def _env_disabled(value: str) -> bool:
+    return value.lower() in {"none", "disabled"}
+
+
 def _resolve_binary(binary_name: str, env_var: str) -> str | None:
     override = os.environ.get(env_var)
     if override:
-        if override.lower() in {"none", "disabled"}:
+        if _env_disabled(override):
             return None
         return override
     return shutil.which(binary_name)
+
+
+def _resolve_openclaw_bridge_binary() -> str | None:
+    bridge = os.environ.get(
+        "STEALTH_BROWSER_OPENCLAW_CAMOUFOX_NIXOS_BIN",
+        DEFAULT_OPENCLAW_CAMOUFOX_NIXOS,
+    )
+    if not bridge or _env_disabled(bridge):
+        return None
+    if os.path.isfile(bridge) and os.access(bridge, os.X_OK):
+        return bridge
+    return None
 
 
 def _pybox_available(distrobox_binary: str) -> bool:
@@ -57,7 +74,13 @@ def _pybox_available(distrobox_binary: str) -> bool:
 
 
 def find_host_native_runtime() -> BrowserRuntime | None:
-    binary = _resolve_binary("camoufox-nixos", "STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN")
+    override = os.environ.get("STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN")
+    if override:
+        if _env_disabled(override):
+            return None
+        return BrowserRuntime(kind="host-native", binary=override)
+
+    binary = _resolve_openclaw_bridge_binary() or shutil.which("camoufox-nixos")
     if not binary:
         return None
     return BrowserRuntime(kind="host-native", binary=binary)

--- a/scripts/runtime_support.py
+++ b/scripts/runtime_support.py
@@ -15,6 +15,14 @@ from typing import Mapping, Sequence
 DEFAULT_DISTROBOX_CONTAINER = "pybox"
 DEFAULT_DISTROBOX_PYTHON = "python3.14"
 DEFAULT_OPENCLAW_CAMOUFOX_NIXOS = "/data/bin/camoufox-nixos"
+OPENCLAW_CONTEXT_ENV_VARS = (
+    "OPENCLAW_HOME",
+    "OPENCLAW_STATE_DIR",
+    "OPENCLAW_CONFIG_PATH",
+    "OPENCLAW_CLI",
+    "ALPHACLAW_ROOT_DIR",
+    "ALPHACLAW_CAMOUFOX_BRIDGE_SOCKET",
+)
 
 
 @dataclass(frozen=True)
@@ -37,6 +45,10 @@ def _env_disabled(value: str) -> bool:
     return value.lower() in {"none", "disabled"}
 
 
+def _env_false(value: str) -> bool:
+    return value.lower() in {"0", "false", "no", "none", "disabled"}
+
+
 def _resolve_binary(binary_name: str, env_var: str) -> str | None:
     override = os.environ.get(env_var)
     if override:
@@ -56,6 +68,25 @@ def _resolve_openclaw_bridge_binary() -> str | None:
     if os.path.isfile(bridge) and os.access(bridge, os.X_OK):
         return bridge
     return None
+
+
+def _openclaw_context_enabled() -> bool:
+    override = os.environ.get("STEALTH_BROWSER_OPENCLAW_CONTEXT")
+    if override is not None:
+        return not _env_false(override)
+    return any(os.environ.get(name) for name in OPENCLAW_CONTEXT_ENV_VARS)
+
+
+def _same_binary(left: str, right: str) -> bool:
+    try:
+        return os.path.samefile(left, right)
+    except OSError:
+        return os.path.abspath(left) == os.path.abspath(right)
+
+
+def _is_openclaw_bridge_runtime(runtime: BrowserRuntime) -> bool:
+    bridge = _resolve_openclaw_bridge_binary()
+    return bool(bridge and _same_binary(runtime.binary, bridge))
 
 
 def _pybox_available(distrobox_binary: str) -> bool:
@@ -80,7 +111,8 @@ def find_host_native_runtime() -> BrowserRuntime | None:
             return None
         return BrowserRuntime(kind="host-native", binary=override)
 
-    binary = _resolve_openclaw_bridge_binary() or shutil.which("camoufox-nixos")
+    bridge = _resolve_openclaw_bridge_binary() if _openclaw_context_enabled() else None
+    binary = bridge or shutil.which("camoufox-nixos")
     if not binary:
         return None
     return BrowserRuntime(kind="host-native", binary=binary)
@@ -122,6 +154,8 @@ def run_camoufox_nixos(
     env = os.environ.copy()
     if extra_env:
         env.update(extra_env)
+    if _is_openclaw_bridge_runtime(runtime):
+        env.pop("CAMOUFOX_NIXOS_STATE_ROOT", None)
     try:
         result = subprocess.run(
             [runtime.binary, *args],

--- a/tests/camoufox-fetch-adapter.sh
+++ b/tests/camoufox-fetch-adapter.sh
@@ -6,8 +6,10 @@ FIXTURES="$ROOT/tests/fixtures"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
-export STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN="$FIXTURES/fake_camoufox_nixos.py"
+export STEALTH_BROWSER_OPENCLAW_CAMOUFOX_NIXOS_BIN="$FIXTURES/fake_camoufox_nixos.py"
+unset STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN
 export STEALTH_BROWSER_DISTROBOX_BIN=none
+export FAKE_CAMOUFOX_LOG="$TMPDIR/camoufox.log"
 
 HTML_OUT="$TMPDIR/page.html"
 SHOT_OUT="$TMPDIR/page.png"
@@ -24,6 +26,7 @@ grep -q "NixOS-native runtime" "$STDOUT_OUT"
 grep -q "HTML saved" "$STDOUT_OUT"
 grep -q "Example Domain" "$HTML_OUT"
 test -s "$SHOT_OUT"
+grep -q "state_root= args=open" "$FAKE_CAMOUFOX_LOG"
 
 export STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN=none
 export STEALTH_BROWSER_DISTROBOX_BIN="$FIXTURES/fake_distrobox.sh"

--- a/tests/camoufox-fetch-adapter.sh
+++ b/tests/camoufox-fetch-adapter.sh
@@ -9,7 +9,9 @@ trap 'rm -rf "$TMPDIR"' EXIT
 export STEALTH_BROWSER_OPENCLAW_CAMOUFOX_NIXOS_BIN="$FIXTURES/fake_camoufox_nixos.py"
 unset STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN
 export STEALTH_BROWSER_DISTROBOX_BIN=none
+export STEALTH_BROWSER_OPENCLAW_CONTEXT=1
 export FAKE_CAMOUFOX_LOG="$TMPDIR/camoufox.log"
+export CAMOUFOX_NIXOS_STATE_ROOT="$TMPDIR/stale-state-root"
 
 HTML_OUT="$TMPDIR/page.html"
 SHOT_OUT="$TMPDIR/page.png"
@@ -27,6 +29,10 @@ grep -q "HTML saved" "$STDOUT_OUT"
 grep -q "Example Domain" "$HTML_OUT"
 test -s "$SHOT_OUT"
 grep -q "state_root= args=open" "$FAKE_CAMOUFOX_LOG"
+if grep -q "$TMPDIR/stale-state-root" "$FAKE_CAMOUFOX_LOG"; then
+  echo "stale CAMOUFOX_NIXOS_STATE_ROOT leaked into bridge runtime" >&2
+  exit 1
+fi
 
 export STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN=none
 export STEALTH_BROWSER_DISTROBOX_BIN="$FIXTURES/fake_distrobox.sh"

--- a/tests/camoufox-session-adapter.sh
+++ b/tests/camoufox-session-adapter.sh
@@ -9,6 +9,7 @@ trap 'rm -rf "$TMPDIR"' EXIT
 export STEALTH_BROWSER_OPENCLAW_CAMOUFOX_NIXOS_BIN="$FIXTURES/fake_camoufox_nixos.py"
 unset STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN
 export STEALTH_BROWSER_DISTROBOX_BIN=none
+export STEALTH_BROWSER_OPENCLAW_CONTEXT=1
 
 STATUS_OUT="$TMPDIR/status.stdout"
 python3 "$ROOT/scripts/camoufox-session.py" \

--- a/tests/camoufox-session-adapter.sh
+++ b/tests/camoufox-session-adapter.sh
@@ -6,7 +6,8 @@ FIXTURES="$ROOT/tests/fixtures"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
-export STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN="$FIXTURES/fake_camoufox_nixos.py"
+export STEALTH_BROWSER_OPENCLAW_CAMOUFOX_NIXOS_BIN="$FIXTURES/fake_camoufox_nixos.py"
+unset STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN
 export STEALTH_BROWSER_DISTROBOX_BIN=none
 
 STATUS_OUT="$TMPDIR/status.stdout"

--- a/tests/fixtures/fake_camoufox_nixos.py
+++ b/tests/fixtures/fake_camoufox_nixos.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -25,6 +26,12 @@ def payload(command: str, data: dict | None = None, page: dict | None = None) ->
 
 def main() -> int:
     args = sys.argv[1:]
+    log_path = os.environ.get("FAKE_CAMOUFOX_LOG")
+    if log_path:
+        with Path(log_path).open("a", encoding="utf-8") as handle:
+            state_root = os.environ.get("CAMOUFOX_NIXOS_STATE_ROOT", "")
+            handle.write(f"state_root={state_root} args={' '.join(args)}\n")
+
     if not args:
         print(json.dumps({"ok": False, "command": "unknown", "data": {}, "error": {"message": "missing command"}}))
         return 1

--- a/tests/runtime-selection.sh
+++ b/tests/runtime-selection.sh
@@ -3,11 +3,27 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FIXTURES="$ROOT/tests/fixtures"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+ln -s "$FIXTURES/fake_camoufox_nixos.py" "$TMPDIR/camoufox-nixos"
 
 export PYTHONPATH="$ROOT/scripts"
 export STEALTH_BROWSER_OPENCLAW_CAMOUFOX_NIXOS_BIN="$FIXTURES/fake_camoufox_nixos.py"
 unset STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN
 export STEALTH_BROWSER_DISTROBOX_BIN="$FIXTURES/fake_distrobox.sh"
+export PATH="$TMPDIR:$PATH"
+export STEALTH_BROWSER_OPENCLAW_CONTEXT=0
+
+python3 - <<'PY'
+from runtime_support import detect_browser_runtime
+
+selection = detect_browser_runtime()
+assert selection.runtime is not None
+assert selection.runtime.kind == "host-native"
+assert selection.runtime.binary.endswith("/camoufox-nixos")
+PY
+
+export STEALTH_BROWSER_OPENCLAW_CONTEXT=1
 
 python3 - <<'PY'
 from runtime_support import detect_browser_runtime

--- a/tests/runtime-selection.sh
+++ b/tests/runtime-selection.sh
@@ -5,7 +5,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FIXTURES="$ROOT/tests/fixtures"
 
 export PYTHONPATH="$ROOT/scripts"
-export STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN="$FIXTURES/fake_camoufox_nixos.py"
+export STEALTH_BROWSER_OPENCLAW_CAMOUFOX_NIXOS_BIN="$FIXTURES/fake_camoufox_nixos.py"
+unset STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN
 export STEALTH_BROWSER_DISTROBOX_BIN="$FIXTURES/fake_distrobox.sh"
 
 python3 - <<'PY'
@@ -14,6 +15,18 @@ from runtime_support import detect_browser_runtime
 selection = detect_browser_runtime()
 assert selection.runtime is not None
 assert selection.runtime.kind == "host-native"
+assert selection.runtime.binary.endswith("fake_camoufox_nixos.py")
+PY
+
+export STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN="/tmp/explicit-camoufox-nixos"
+
+python3 - <<'PY'
+from runtime_support import detect_browser_runtime
+
+selection = detect_browser_runtime()
+assert selection.runtime is not None
+assert selection.runtime.kind == "host-native"
+assert selection.runtime.binary == "/tmp/explicit-camoufox-nixos"
 PY
 
 export STEALTH_BROWSER_CAMOUFOX_NIXOS_BIN=none


### PR DESCRIPTION
## Summary

OpenClaw Camoufox runs now select the working `/data/bin/camoufox-nixos` bridge before falling back to the direct host wrapper, so agents no longer misdiagnose bridge-capable runs as missing `/data/.local/venvs/camoufox`. Explicit runtime overrides still win for diagnostics, and setting the override to `none` still forces the distrobox/no-runtime path.

The fetch adapter also stops forcing a temporary `CAMOUFOX_NIXOS_STATE_ROOT`, leaving bridge state mapping to the bridge wrapper. The skill docs now make the OpenClaw native-browser-first rule and the Camoufox bridge path explicit; this branch also carries the prior display/rebuild guidance commit.

## Validation

- `bash tests/runtime-selection.sh`
- `bash tests/camoufox-fetch-adapter.sh`
- `bash tests/camoufox-session-adapter.sh`
- `bash scripts/test-discovery.sh`
- `bash scripts/lint-skill.sh`
- `python3 -m py_compile scripts/runtime_support.py scripts/camoufox-fetch.py scripts/camoufox-session.py tests/fixtures/fake_camoufox_nixos.py`
- `./scripts/camoufox-fetch.py https://example.com --headless --wait 0 --output /tmp/camoufox_fetch_bridge_lfg.html`
- `./scripts/camoufox-fetch.py https://example.com --headless --wait 0 --output /tmp/camoufox_fetch_browser_step.html`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
